### PR TITLE
added missing package - resolvconf

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -85,13 +85,13 @@ if [[ "$OS" = 'ubuntu' ]]; then
     add-apt-repository ppa:wireguard/wireguard
     apt-get update
     apt-get install "linux-headers-$(uname -r)"
-    apt-get install wireguard iptables
+    apt-get install wireguard iptables resolvconf
 elif [[ "$OS" = 'debian' ]]; then
     echo "deb http://deb.debian.org/debian/ unstable main" > /etc/apt/sources.list.d/unstable.list
     printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' > /etc/apt/preferences.d/limit-unstable
     apt update
     apt-get install "linux-headers-$(uname -r)"
-    apt install wireguard iptables
+    apt install wireguard iptables resolvconf
 elif [[ "$OS" = 'fedora' ]]; then
     dnf copr enable jdoss/wireguard
     dnf install wireguard-dkms wireguard-tools iptables


### PR DESCRIPTION
without resolvconf package, systemd unit file will fail in Debian 10 and ubuntu 18.04 or higher versions
see error below 

```
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip link add wg0 type wireguard
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] wg setconf wg0 /dev/fd/63
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip -4 address add 10.9.0.3/24 dev wg0
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip link set mtu 1420 up dev wg0
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] resolvconf -a wg0 -m 0 -x
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: /usr/bin/wg-quick: line 31: resolvconf: command not found
Oct 17 12:11:39 Asus-VivoBook wg-quick[25620]: [#] ip link delete dev wg0
Oct 17 12:11:39 Asus-VivoBook systemd[1]: wg-quick@wg0.service: Main process exited
```
more info here : https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=930735