### PR TITLE
Use native WireGuard in Fedora >= 32 + support firewalld

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -127,9 +127,10 @@ ListenPort = $SERVER_PORT
 PrivateKey = $SERVER_PRIV_KEY" > "/etc/wireguard/$SERVER_WG_NIC.conf"
 
 if [[ "$OS" = 'fedora' ]]; then
-    FIREWALLD_ADDRESS=$(echo $SERVER_WG_IPV4 | cut -d"." -f1-3)".0"
-    echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_ADDRESS/24 masquerade'
-PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_ADDRESS/24 masquerade'" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
+    FIREWALLD_IPV4_ADDRESS=$(echo $SERVER_WG_IPV4 | cut -d"." -f1-3)".0"
+    FIREWALLD_IPV6_ADDRESS=$(echo $SERVER_WG_IPV6 | sed 's/:[^:]*$/:0/')
+    echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'
+PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
 else
     echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
 PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >> "/etc/wireguard/$SERVER_WG_NIC.conf"

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -130,7 +130,7 @@ if [[ "$OS" = 'fedora' ]]; then
     FIREWALLD_IPV4_ADDRESS=$(echo $SERVER_WG_IPV4 | cut -d"." -f1-3)".0"
     FIREWALLD_IPV6_ADDRESS=$(echo $SERVER_WG_IPV6 | sed 's/:[^:]*$/:0/')
     echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'
-PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
+PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
 else
     echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
 PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >> "/etc/wireguard/$SERVER_WG_NIC.conf"

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -126,7 +126,7 @@ Address = $SERVER_WG_IPV4/24,$SERVER_WG_IPV6/64
 ListenPort = $SERVER_PORT
 PrivateKey = $SERVER_PRIV_KEY" > "/etc/wireguard/$SERVER_WG_NIC.conf"
 
-if [[ "$OS" = 'fedora' ]]; then
+if [ -x "$(command -v firewall-cmd)" ]; then
     FIREWALLD_IPV4_ADDRESS=$(echo $SERVER_WG_IPV4 | cut -d"." -f1-3)".0"
     FIREWALLD_IPV6_ADDRESS=$(echo $SERVER_WG_IPV6 | sed 's/:[^:]*$/:0/')
     echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -94,13 +94,12 @@ elif [[ "$OS" = 'debian' ]]; then
     apt-get install -y "linux-headers-$(uname -r)"
     apt-get install -y wireguard iptables resolvconf qrencode
 elif [[ "$OS" = 'fedora' ]]; then
-    if [[ "$VERSION_ID" -ge 32 ]]; then
-        dnf install -y wireguard-tools iptables qrencode
-    else
+    if [[ "$VERSION_ID" -lt 32 ]]; then
         dnf install -y dnf-plugins-core
         dnf copr enable -y jdoss/wireguard
-        dnf install -y wireguard-dkms wireguard-tools iptables qrencode
+        dnf install -y wireguard-dkms 
     fi
+    dnf install -y wireguard-tools iptables qrencode
 elif [[ "$OS" = 'centos' ]]; then
     curl -Lo /etc/yum.repos.d/wireguard.repo https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
     yum -y install epel-release

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -126,17 +126,13 @@ Address = $SERVER_WG_IPV4/24,$SERVER_WG_IPV6/64
 ListenPort = $SERVER_PORT
 PrivateKey = $SERVER_PRIV_KEY" > "/etc/wireguard/$SERVER_WG_NIC.conf"
 
-# Add iptables rules
-if [[ "$OS" != 'fedora' ]]; then
-    echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
-PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
-fi
-
-# Add firewalld rules
 if [[ "$OS" = 'fedora' ]]; then
     FIREWALLD_ADDRESS=$(echo $SERVER_WG_IPV4 | cut -d"." -f1-3)".0"
     echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_ADDRESS/24 masquerade'
 PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_ADDRESS/24 masquerade'" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
+else
+    echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
+PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
 fi
 
 # Add the client as a peer to the server

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -24,7 +24,8 @@ if [[ -e /etc/debian_version ]]; then
     source /etc/os-release
     OS=$ID # debian or ubuntu
 elif [[ -e /etc/fedora-release ]]; then
-    OS=fedora
+    source /etc/os-release
+    OS=$ID
 elif [[ -e /etc/centos-release ]]; then
     OS=centos
 elif [[ -e /etc/arch-release ]]; then
@@ -93,9 +94,13 @@ elif [[ "$OS" = 'debian' ]]; then
     apt-get install -y "linux-headers-$(uname -r)"
     apt-get install -y wireguard iptables resolvconf qrencode
 elif [[ "$OS" = 'fedora' ]]; then
-    dnf install -y dnf-plugins-core
-    dnf copr enable -y jdoss/wireguard
-    dnf install -y wireguard-dkms wireguard-tools iptables qrencode
+    if [[ "$VERSION_ID" -ge 32 ]]; then
+        dnf install -y wireguard-tools iptables qrencode
+    else
+        dnf install -y dnf-plugins-core
+        dnf copr enable -y jdoss/wireguard
+        dnf install -y wireguard-dkms wireguard-tools iptables qrencode
+    fi
 elif [[ "$OS" = 'centos' ]]; then
     curl -Lo /etc/yum.repos.d/wireguard.repo https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
     yum -y install epel-release

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -125,9 +125,20 @@ CLIENT_PUB_KEY=$(echo "$CLIENT_PRIV_KEY" | wg pubkey)
 echo "[Interface]
 Address = $SERVER_WG_IPV4/24,$SERVER_WG_IPV6/64
 ListenPort = $SERVER_PORT
-PrivateKey = $SERVER_PRIV_KEY
-PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
-PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" > "/etc/wireguard/$SERVER_WG_NIC.conf"
+PrivateKey = $SERVER_PRIV_KEY" > "/etc/wireguard/$SERVER_WG_NIC.conf"
+
+# Add iptables rules
+if [[ "$OS" != 'fedora' ]]; then
+    echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
+PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
+fi
+
+# Add firewalld rules
+if [[ "$OS" = 'fedora' ]]; then
+    FIREWALLD_ADDRESS=$(echo $SERVER_WG_IPV4 | cut -d"." -f1-3)".0"
+    echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_ADDRESS/24 masquerade'
+PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_ADDRESS/24 masquerade'" >> "/etc/wireguard/$SERVER_WG_NIC.conf"
+fi
 
 # Add the client as a peer to the server
 echo "[Peer]


### PR DESCRIPTION
Added extended Fedora support:
* Use native Wireguard in Fedora >= 32
* Use firewalld configuration

Solves and simplifies https://github.com/angristan/wireguard-install/issues/54