### PR TITLE
Change Wireguard port from OpenVPN default

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -52,7 +52,8 @@ read -rp "Server's WireGuard IPv4 " -e -i "$SERVER_WG_IPV4" SERVER_WG_IPV4
 SERVER_WG_IPV6="fd42:42:42::1"
 read -rp "Server's WireGuard IPv6 " -e -i "$SERVER_WG_IPV6" SERVER_WG_IPV6
 
-SERVER_PORT=51820
+# Generate random number within private ports range
+SERVER_PORT=$(shuf -i49152-65535 -n1)
 read -rp "Server's WireGuard port " -e -i "$SERVER_PORT" SERVER_PORT
 
 CLIENT_WG_IPV4="10.66.66.2"

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -52,7 +52,7 @@ read -rp "Server's WireGuard IPv4 " -e -i "$SERVER_WG_IPV4" SERVER_WG_IPV4
 SERVER_WG_IPV6="fd42:42:42::1"
 read -rp "Server's WireGuard IPv6 " -e -i "$SERVER_WG_IPV6" SERVER_WG_IPV6
 
-SERVER_PORT=1194
+SERVER_PORT=51820
 read -rp "Server's WireGuard port " -e -i "$SERVER_PORT" SERVER_PORT
 
 CLIENT_WG_IPV4="10.66.66.2"


### PR DESCRIPTION
Current port `1194` conflicts with OpenVPN listening port.
Wireguard docs use port `51820` so we'll use that.

Fix #63.