### PR TITLE
Fix for #2 : Added uninstallation steps

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
+function checkOS() {
+    # Check OS version
+    if [[ -e /etc/debian_version ]]; then
+        source /etc/os-release
+        OS=$ID # debian or ubuntu
+    elif [[ -e /etc/fedora-release ]]; then
+        source /etc/os-release
+        OS=$ID
+    elif [[ -e /etc/centos-release ]]; then
+        OS=centos
+    elif [[ -e /etc/arch-release ]]; then
+        OS=arch
+    else
+        echo "Looks like you aren't running this installer on a Debian, Ubuntu, Fedora, CentOS or Arch Linux system"
+        exit 1
+    fi
+}
+
 function addClient() {
 	# Load params
 	source /etc/wireguard/params
@@ -62,6 +80,69 @@ AllowedIPs = $CLIENT_WG_IPV4/32,$CLIENT_WG_IPV6/128" >>"/etc/wireguard/$SERVER_W
 	echo "It is also available in $HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
 }
 
+function uninstall() {
+
+## To uninstall wireguard and its setup ##
+
+
+#Check OS type
+checkOS
+
+#get WireGuard interface name
+SERVER_WG_NIC="wg0"
+read -rp "WireGuard interface name: " -e -i "$SERVER_WG_NIC" SERVER_WG_NIC
+
+ip link set down "$SERVER_WG_NIC"		#stop wireguard interface
+
+#Remove wireguard tool and qrencode
+if [[ $OS == 'ubuntu' ]]; then
+    apt-get remove --purge -y wireguard qrencode
+	add-apt-repository -y -r ppa:wireguard/wireguard
+	apt-get autoremove -y
+elif [[ $OS == 'debian' ]]; then
+	apt-get remove --purge -y wireguard qrencode
+	apt-get autoremove -y
+elif [[ $OS == 'fedora' ]]; then
+    dnf remove -y wireguard-tools qrencode
+	if [[ $VERSION_ID -lt 32 ]]; then
+		dnf remove -y wireguard-dkms
+		dnf copr disable -y jdoss/wireguard
+	fi
+	dnf autoremove -y
+elif [[ $OS == 'centos' ]]; then
+	yum -y remove wireguard-dkms wireguard-tools qrencode
+	yum -y autoremove
+elif [[ $OS == 'arch' ]]; then
+	pacman -Rs --noconfirm wireguard-tools wireguard-arch qrencode
+fi
+
+#Delete /etc/wireguard
+rm -rfv /etc/wireguard > /dev/null 2>&1
+
+if [[ -e /etc/sysctl.d/wg.conf ]]; then
+    #Delete wg.conf
+    rm -fv /etc/sysctl.d/wg.conf
+fi
+
+sysctl --system
+
+systemctl stop "wg-quick@$SERVER_WG_NIC"
+systemctl disable "wg-quick@$SERVER_WG_NIC"
+ip link delete "$SERVER_WG_NIC"	#delete wireguard interface
+# Check if WireGuard is running
+systemctl is-active --quiet "wg-quick@$SERVER_WG_NIC"
+WG_RUNNING=$?
+
+if [[ $WG_RUNNING -ne 0 ]]; then
+    echo "WireGuard failed to uninstall properly."
+    exit 1
+else
+    echo "WireGuard uninstalled successfully."
+    exit 0
+fi
+
+}
+
 if [ "$EUID" -ne 0 ]; then
 	echo "You need to run this script as root"
 	exit 1
@@ -89,27 +170,20 @@ if [[ $1 == "add-client" ]]; then
 		echo "Please install WireGuard first."
 		exit 1
 	fi
+elif [[ $1 == "uninstall" ]]; then
+	if [[ -e /etc/wireguard ]]; then
+		uninstall
+        exit 0
+	else
+		echo "WireGuard is not installed."
+		exit 1
+	fi
 elif [[ -e /etc/wireguard ]]; then
-	echo "WireGuard is already installed. Run with 'add-client' to add a client."
+	echo "WireGuard is already installed. Run with 'add-client' to add a client or 'uninstall' to remove."
 	exit 1
 fi
 
-# Check OS version
-if [[ -e /etc/debian_version ]]; then
-	source /etc/os-release
-	OS=$ID # debian or ubuntu
-elif [[ -e /etc/fedora-release ]]; then
-	source /etc/os-release
-	OS=$ID
-elif [[ -e /etc/centos-release ]]; then
-	OS=centos
-elif [[ -e /etc/arch-release ]]; then
-	OS=arch
-else
-	echo "Looks like you aren't running this installer on a Debian, Ubuntu, Fedora, CentOS or Arch Linux system"
-	exit 1
-fi
-
+checkOS
 # Detect public IPv4 address and pre-fill for the user
 SERVER_PUB_IPV4=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
 read -rp "IPv4 or IPv6 public address: " -e -i "$SERVER_PUB_IPV4" SERVER_PUB_IP


### PR DESCRIPTION
WireGuard can be uninstalled by running

`sudo bash wireguard-install.sh uninstall`

Changes:

- Encapsulated Check OS commands under function 'checkOS'
- Added uninstallation steps, under 'uninstall' function

if $1 is "uninstall" --> Check if /etc/wireguard exist --> if yes proceed with uninstallation or else print wireGuard not installed.

1. Get WireGuard interface name from user: wg0
2. Stop WireGuard Interface.
3. checkOS
4. Remove wireguard tool and qrencode.
5. Delete directory /etc/wireguard
6. Delete file /etc/sysctl.d/wg.conf if exist
7. Configure system parameters. sysctl --system
8. Stop wireguard service and disable it.
9. Delete wireguard interface
9. Check if wg service is stopped.
10. Exit

Tested on:

- [x] Ubuntu 18.04
- [x] CentOS 8.1
- [x] Fedora 32
- [x] Arch Linux 2020.06.01
