### PR TITLE
Refactor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ chmod +x wireguard-install.sh
 
 It will install WireGuard (kernel module and tools) on the server, configure it, create a systemd service and a client configuration file.
 
-To generate more client files, run the following:
-
-```sh
-./wireguard-install.sh add-client
-```
-
 Make sure you choose different IPs for you clients.
 
 Contributions are welcome!

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+function isRoot() {
+	if [ "$EUID" -ne 0 ]; then
+		echo "You need to run this script as root"
+		exit 1
+	fi
+}
+
 function addClient() {
 	# Load params
 	source /etc/wireguard/params
@@ -61,11 +68,6 @@ AllowedIPs = $CLIENT_WG_IPV4/32,$CLIENT_WG_IPV6/128" >>"/etc/wireguard/$SERVER_W
 
 	echo "It is also available in $HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
 }
-
-if [ "$EUID" -ne 0 ]; then
-	echo "You need to run this script as root"
-	exit 1
-fi
 
 if [ "$(systemd-detect-virt)" == "openvz" ]; then
 	echo "OpenVZ is not supported"

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -240,7 +240,7 @@ function newClient() {
 	# Create client file and add the server as a peer
 	echo "[Interface]
 PrivateKey = ${CLIENT_PRIV_KEY}
-Address = ${CLIENT_WG_IPV4}/24,${CLIENT_WG_IPV6}/64
+Address = ${CLIENT_WG_IPV4}/32,${CLIENT_WG_IPV6}/128
 DNS = ${CLIENT_DNS_1},${CLIENT_DNS_2}
 
 [Peer]

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -93,6 +93,17 @@ function installQuestions() {
 		read -rp "Server's WireGuard port [1-65535]: " -e -i "${RANDOM_PORT}" SERVER_PORT
 	done
 
+	# Adguard DNS by default
+	until [[ "${CLIENT_DNS_1}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
+		read -rp "First DNS resolver to use for the client: " -e -i 176.103.130.130 CLIENT_DNS_1
+	done
+	until [[ "${CLIENT_DNS_2}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
+		read -rp "Second DNS resolver to use for the client (optional): " -e -i 176.103.130.131 CLIENT_DNS_2
+		if [[ "${CLIENT_DNS_2}" == "" ]]; then
+			CLIENT_DNS_2="${CLIENT_DNS_1}"
+		fi
+	done
+
 	echo ""
 	echo "Okay, that was all I needed. We are ready to setup your WireGuard server now."
 	echo "You will be able to generate a client at the end of the installation."
@@ -149,7 +160,9 @@ SERVER_WG_IPV4=${SERVER_WG_IPV4}
 SERVER_WG_IPV6=${SERVER_WG_IPV6}
 SERVER_PORT=${SERVER_PORT}
 SERVER_PRIV_KEY=${SERVER_PRIV_KEY}
-SERVER_PUB_KEY=${SERVER_PUB_KEY}" >/etc/wireguard/params
+SERVER_PUB_KEY=${SERVER_PUB_KEY}
+CLIENT_DNS_1=${CLIENT_DNS_1}
+CLIENT_DNS_2=${CLIENT_DNS_2}" >/etc/wireguard/params
 
 	# Add server interface
 	echo "[Interface]
@@ -212,17 +225,6 @@ function newClient() {
 
 	until [[ "${CLIENT_WG_IPV6}" =~ ^([a-f0-9]{1,4}:?:?){3,5} ]]; do
 		read -rp "Client's WireGuard IPv6 : " -e -i "${SERVER_WG_IPV6::-1}"2 CLIENT_WG_IPV6
-	done
-
-	# Adguard DNS by default
-	until [[ "${CLIENT_DNS_1}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
-		read -rp "First DNS resolver to use for the client: " -e -i 176.103.130.130 CLIENT_DNS_1
-	done
-	until [[ "${CLIENT_DNS_2}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
-		read -rp "Second DNS resolver to use for the client (optional): " -e -i 176.103.130.131 CLIENT_DNS_2
-		if [[ "${CLIENT_DNS_2}" == "" ]]; then
-			CLIENT_DNS_2="${CLIENT_DNS_1}"
-		fi
 	done
 
 	CLIENT_NAME=$(

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -186,11 +186,11 @@ function newClient() {
 	fi
 
 	until [[ "$CLIENT_WG_IPV4" =~ ^([0-9]{1,3}\.?){4}$ ]]; do
-		read -rp "Client's WireGuard IPv4: " -e -i 10.66.66.2 CLIENT_WG_IPV4
+		read -rp "Client's WireGuard IPv4: " -e -i "${SERVER_WG_IPV4: : -1}"2 CLIENT_WG_IPV4
 	done
 
 	until [[ "$CLIENT_WG_IPV6" =~ ^([a-f0-9]{1,4}:?:?){3,5} ]]; do
-		read -rp "Client's WireGuard IPv6 : " -e -i fd42:42:42::2 CLIENT_WG_IPV6
+		read -rp "Client's WireGuard IPv6 : " -e -i "${SERVER_WG_IPV6: : -1}"2 CLIENT_WG_IPV6
 	done
 
 	# Adguard DNS by default

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -76,8 +76,10 @@ function installWireGuard() {
 	read -rp "Server's WireGuard IPv6: " -e -i "$SERVER_WG_IPV6" SERVER_WG_IPV6
 
 	# Generate random number within private ports range
-	SERVER_PORT=$(shuf -i49152-65535 -n1)
-	read -rp "Server's WireGuard port: " -e -i "$SERVER_PORT" SERVER_PORT
+	RANDOM_PORT=$(shuf -i49152-65535 -n1)
+	until [[ $SERVER_PORT =~ ^[0-9]+$ ]] && [ "$SERVER_PORT" -ge 1 ] && [ "$SERVER_PORT" -le 65535 ]; do
+		read -rp "Server's WireGuard port [1-65535]: " -e -i "$RANDOM_PORT" SERVER_PORT
+	done
 
 	# Install WireGuard tools and module
 	if [[ $OS == 'ubuntu' ]]; then

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -87,12 +87,12 @@ function installQuestions() {
 		read -rp "WireGuard interface name: " -e -i wg0 SERVER_WG_NIC
 	done
 
-	until [[ "${SERVER_WG_IPV4}" =~ ^([0-9]{1,3}\.){3}1$ ]]; do
-		read -rp "Server's WireGuard IPv4 [x.x.x.1]: " -e -i 10.66.66.1 SERVER_WG_IPV4
+	until [[ "${SERVER_WG_IPV4}" =~ ^([0-9]{1,3}\.){3} ]]; do
+		read -rp "Server's WireGuard IPv4: " -e -i 10.66.66.1 SERVER_WG_IPV4
 	done
 
-	until [[ "${SERVER_WG_IPV6}" =~ ^([a-f0-9]{1,4}:){3,4}:1$ ]]; do
-		read -rp "Server's WireGuard IPv6 [x:x:x::1]: " -e -i fd42:42:42::1 SERVER_WG_IPV6
+	until [[ "${SERVER_WG_IPV6}" =~ ^([a-f0-9]{1,4}:){3,4}: ]]; do
+		read -rp "Server's WireGuard IPv6: " -e -i fd42:42:42::1 SERVER_WG_IPV6
 	done
 
 	# Generate random number within private ports range

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -7,6 +7,22 @@ function isRoot() {
 	fi
 }
 
+function checkVirt() {
+	if [ "$(systemd-detect-virt)" == "openvz" ]; then
+		echo "OpenVZ is not supported"
+		exit 1
+	fi
+
+	if [ "$(systemd-detect-virt)" == "lxc" ]; then
+		echo "LXC is not supported (yet)."
+		echo "WireGuard can technically run in an LXC container,"
+		echo "but the kernel module has to be installed on the host,"
+		echo "the container has to be run with some specific parameters"
+		echo "and only the tools need to be installed in the container."
+		exit 1
+	fi
+}
+
 function addClient() {
 	# Load params
 	source /etc/wireguard/params
@@ -69,19 +85,6 @@ AllowedIPs = $CLIENT_WG_IPV4/32,$CLIENT_WG_IPV6/128" >>"/etc/wireguard/$SERVER_W
 	echo "It is also available in $HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
 }
 
-if [ "$(systemd-detect-virt)" == "openvz" ]; then
-	echo "OpenVZ is not supported"
-	exit
-fi
-
-if [ "$(systemd-detect-virt)" == "lxc" ]; then
-	echo "LXC is not supported (yet)."
-	echo "WireGuard can technically run in an LXC container,"
-	echo "but the kernel module has to be installed on the host,"
-	echo "the container has to be run with some specific parameters"
-	echo "and only the tools need to be installed in the container."
-	exit
-fi
 
 if [[ $1 == "add-client" ]]; then
 	if [[ -e /etc/wireguard/params ]]; then

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -41,6 +41,12 @@ function checkOS() {
 	fi
 }
 
+function initialCheck() {
+	isRoot
+	checkVirt
+	checkOS
+}
+
 function addClient() {
 	# Load params
 	source /etc/wireguard/params

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -95,10 +95,10 @@ function installQuestions() {
 
 	# Adguard DNS by default
 	until [[ "${CLIENT_DNS_1}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
-		read -rp "First DNS resolver to use for the client: " -e -i 176.103.130.130 CLIENT_DNS_1
+		read -rp "First DNS resolver to use for the clients: " -e -i 176.103.130.130 CLIENT_DNS_1
 	done
 	until [[ "${CLIENT_DNS_2}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
-		read -rp "Second DNS resolver to use for the client (optional): " -e -i 176.103.130.131 CLIENT_DNS_2
+		read -rp "Second DNS resolver to use for the clients (optional): " -e -i 176.103.130.131 CLIENT_DNS_2
 		if [[ "${CLIENT_DNS_2}" == "" ]]; then
 			CLIENT_DNS_2="${CLIENT_DNS_1}"
 		fi

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -47,6 +47,125 @@ function initialCheck() {
 	checkOS
 }
 
+function installWireGuard() {
+
+	# Detect public IPv4 address and pre-fill for the user
+	SERVER_PUB_IPV4=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
+	read -rp "IPv4 or IPv6 public address: " -e -i "$SERVER_PUB_IPV4" SERVER_PUB_IP
+
+	# Detect public interface and pre-fill for the user
+	SERVER_PUB_NIC="$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)"
+	read -rp "Public interface: " -e -i "$SERVER_PUB_NIC" SERVER_PUB_NIC
+
+	SERVER_WG_NIC="wg0"
+	read -rp "WireGuard interface name: " -e -i "$SERVER_WG_NIC" SERVER_WG_NIC
+
+	SERVER_WG_IPV4="10.66.66.1"
+	read -rp "Server's WireGuard IPv4: " -e -i "$SERVER_WG_IPV4" SERVER_WG_IPV4
+
+	SERVER_WG_IPV6="fd42:42:42::1"
+	read -rp "Server's WireGuard IPv6: " -e -i "$SERVER_WG_IPV6" SERVER_WG_IPV6
+
+	# Generate random number within private ports range
+	SERVER_PORT=$(shuf -i49152-65535 -n1)
+	read -rp "Server's WireGuard port: " -e -i "$SERVER_PORT" SERVER_PORT
+
+	# Install WireGuard tools and module
+	if [[ $OS == 'ubuntu' ]]; then
+		apt-get install -y software-properties-common
+		add-apt-repository -y ppa:wireguard/wireguard
+		apt-get update
+		apt-get install -y "linux-headers-$(uname -r)"
+		apt-get install -y wireguard iptables resolvconf qrencode
+	elif [[ $OS == 'debian' ]]; then
+		echo "deb http://deb.debian.org/debian/ unstable main" >/etc/apt/sources.list.d/unstable.list
+		printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' >/etc/apt/preferences.d/limit-unstable
+		apt update
+		apt-get install -y "linux-headers-$(uname -r)"
+		apt-get install -y wireguard iptables resolvconf qrencode
+		apt-get install -y bc # mitigate https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956869
+	elif [[ $OS == 'fedora' ]]; then
+		if [[ $VERSION_ID -lt 32 ]]; then
+			dnf install -y dnf-plugins-core
+			dnf copr enable -y jdoss/wireguard
+			dnf install -y wireguard-dkms
+		fi
+		dnf install -y wireguard-tools iptables qrencode
+	elif [[ $OS == 'centos' ]]; then
+		curl -Lo /etc/yum.repos.d/wireguard.repo https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
+		yum -y install epel-release
+		yum -y install wireguard-dkms wireguard-tools iptables qrencode
+	elif [[ $OS == 'arch' ]]; then
+		pacman -S --noconfirm linux-headers
+		pacman -S --noconfirm wireguard-tools iptables qrencode
+	fi
+
+	# Make sure the directory exists (this does not seem the be the case on fedora)
+	mkdir /etc/wireguard >/dev/null 2>&1
+
+	chmod 600 -R /etc/wireguard/
+
+	SERVER_PRIV_KEY=$(wg genkey)
+	SERVER_PUB_KEY=$(echo "$SERVER_PRIV_KEY" | wg pubkey)
+
+	# Save WireGuard settings
+	echo "SERVER_PUB_IP=$SERVER_PUB_IP
+SERVER_PUB_NIC=$SERVER_PUB_NIC
+SERVER_WG_NIC=$SERVER_WG_NIC
+SERVER_WG_IPV4=$SERVER_WG_IPV4
+SERVER_WG_IPV6=$SERVER_WG_IPV6
+SERVER_PORT=$SERVER_PORT
+SERVER_PRIV_KEY=$SERVER_PRIV_KEY
+SERVER_PUB_KEY=$SERVER_PUB_KEY" >/etc/wireguard/params
+
+	source /etc/wireguard/params
+
+	# Add server interface
+	echo "[Interface]
+Address = $SERVER_WG_IPV4/24,$SERVER_WG_IPV6/64
+ListenPort = $SERVER_PORT
+PrivateKey = $SERVER_PRIV_KEY" >"/etc/wireguard/$SERVER_WG_NIC.conf"
+
+	if [ -x "$(command -v firewall-cmd)" ]; then
+		FIREWALLD_IPV4_ADDRESS=$(echo "$SERVER_WG_IPV4" | cut -d"." -f1-3)".0"
+		FIREWALLD_IPV6_ADDRESS=$(echo "$SERVER_WG_IPV6" | sed 's/:[^:]*$/:0/')
+		echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'
+PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
+	else
+		echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
+PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
+	fi
+
+	# Enable routing on the server
+	echo "net.ipv4.ip_forward = 1
+net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
+
+	sysctl --system
+
+	systemctl start "wg-quick@$SERVER_WG_NIC"
+	systemctl enable "wg-quick@$SERVER_WG_NIC"
+
+	# Check if WireGuard is running
+	systemctl is-active --quiet "wg-quick@$SERVER_WG_NIC"
+	WG_RUNNING=$?
+
+	# Warn user about kernel version mismatch with headers
+	if [[ $OS =~ (fedora|centos) ]] && [[ $WG_RUNNING -ne 0 ]]; then
+		echo -e "\nWARNING: WireGuard does not seem to be running."
+		echo "Due to kernel mismatch issues on $OS, WireGuard might work if your system is out of date."
+		echo "You can check if WireGuard is running with: systemctl status wg-quick@$SERVER_WG_NIC"
+		echo 'If you get something like "Cannot find device wg0", please run:'
+		if [[ $OS == 'fedora' ]]; then
+			echo "dnf update -y && reboot"
+		elif [[ $OS == 'centos' ]]; then
+			echo "yum update -y && reboot"
+		fi
+	fi
+
+	addClient
+	echo "If you want to add more clients, you simply need to run this script another time!"
+}
+
 function addClient() {
 	# Load params
 	source /etc/wireguard/params
@@ -109,7 +228,6 @@ AllowedIPs = $CLIENT_WG_IPV4/32,$CLIENT_WG_IPV6/128" >>"/etc/wireguard/$SERVER_W
 	echo "It is also available in $HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
 }
 
-
 if [[ $1 == "add-client" ]]; then
 	if [[ -e /etc/wireguard/params ]]; then
 		addClient
@@ -122,118 +240,3 @@ elif [[ -e /etc/wireguard/params ]]; then
 	echo "WireGuard is already installed. Run with 'add-client' to add a client."
 	exit 1
 fi
-
-# Detect public IPv4 address and pre-fill for the user
-SERVER_PUB_IPV4=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
-read -rp "IPv4 or IPv6 public address: " -e -i "$SERVER_PUB_IPV4" SERVER_PUB_IP
-
-# Detect public interface and pre-fill for the user
-SERVER_PUB_NIC="$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)"
-read -rp "Public interface: " -e -i "$SERVER_PUB_NIC" SERVER_PUB_NIC
-
-SERVER_WG_NIC="wg0"
-read -rp "WireGuard interface name: " -e -i "$SERVER_WG_NIC" SERVER_WG_NIC
-
-SERVER_WG_IPV4="10.66.66.1"
-read -rp "Server's WireGuard IPv4: " -e -i "$SERVER_WG_IPV4" SERVER_WG_IPV4
-
-SERVER_WG_IPV6="fd42:42:42::1"
-read -rp "Server's WireGuard IPv6: " -e -i "$SERVER_WG_IPV6" SERVER_WG_IPV6
-
-# Generate random number within private ports range
-SERVER_PORT=$(shuf -i49152-65535 -n1)
-read -rp "Server's WireGuard port: " -e -i "$SERVER_PORT" SERVER_PORT
-
-# Install WireGuard tools and module
-if [[ $OS == 'ubuntu' ]]; then
-	apt-get install -y software-properties-common
-	add-apt-repository -y ppa:wireguard/wireguard
-	apt-get update
-	apt-get install -y "linux-headers-$(uname -r)"
-	apt-get install -y wireguard iptables resolvconf qrencode
-elif [[ $OS == 'debian' ]]; then
-	echo "deb http://deb.debian.org/debian/ unstable main" >/etc/apt/sources.list.d/unstable.list
-	printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' >/etc/apt/preferences.d/limit-unstable
-	apt update
-	apt-get install -y "linux-headers-$(uname -r)"
-	apt-get install -y wireguard iptables resolvconf qrencode
-	apt-get install -y bc # mitigate https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956869
-elif [[ $OS == 'fedora' ]]; then
-	if [[ $VERSION_ID -lt 32 ]]; then
-		dnf install -y dnf-plugins-core
-		dnf copr enable -y jdoss/wireguard
-		dnf install -y wireguard-dkms
-	fi
-	dnf install -y wireguard-tools iptables qrencode
-elif [[ $OS == 'centos' ]]; then
-	curl -Lo /etc/yum.repos.d/wireguard.repo https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
-	yum -y install epel-release
-	yum -y install wireguard-dkms wireguard-tools iptables qrencode
-elif [[ $OS == 'arch' ]]; then
-	pacman -S --noconfirm linux-headers
-	pacman -S --noconfirm wireguard-tools iptables qrencode
-fi
-
-# Make sure the directory exists (this does not seem the be the case on fedora)
-mkdir /etc/wireguard >/dev/null 2>&1
-
-chmod 600 -R /etc/wireguard/
-
-SERVER_PRIV_KEY=$(wg genkey)
-SERVER_PUB_KEY=$(echo "$SERVER_PRIV_KEY" | wg pubkey)
-
-# Save WireGuard settings
-echo "SERVER_PUB_IP=$SERVER_PUB_IP
-SERVER_PUB_NIC=$SERVER_PUB_NIC
-SERVER_WG_NIC=$SERVER_WG_NIC
-SERVER_WG_IPV4=$SERVER_WG_IPV4
-SERVER_WG_IPV6=$SERVER_WG_IPV6
-SERVER_PORT=$SERVER_PORT
-SERVER_PRIV_KEY=$SERVER_PRIV_KEY
-SERVER_PUB_KEY=$SERVER_PUB_KEY" >/etc/wireguard/params
-
-source /etc/wireguard/params
-
-# Add server interface
-echo "[Interface]
-Address = $SERVER_WG_IPV4/24,$SERVER_WG_IPV6/64
-ListenPort = $SERVER_PORT
-PrivateKey = $SERVER_PRIV_KEY" >"/etc/wireguard/$SERVER_WG_NIC.conf"
-
-if [ -x "$(command -v firewall-cmd)" ]; then
-	FIREWALLD_IPV4_ADDRESS=$(echo "$SERVER_WG_IPV4" | cut -d"." -f1-3)".0"
-	FIREWALLD_IPV6_ADDRESS=$(echo "$SERVER_WG_IPV6" | sed 's/:[^:]*$/:0/')
-	echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'
-PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
-else
-	echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
-PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
-fi
-
-# Enable routing on the server
-echo "net.ipv4.ip_forward = 1
-net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
-
-sysctl --system
-
-systemctl start "wg-quick@$SERVER_WG_NIC"
-systemctl enable "wg-quick@$SERVER_WG_NIC"
-
-# Check if WireGuard is running
-systemctl is-active --quiet "wg-quick@$SERVER_WG_NIC"
-WG_RUNNING=$?
-
-# Warn user about kernel version mismatch with headers
-if [[ $OS =~ (fedora|centos) ]] && [[ $WG_RUNNING -ne 0 ]]; then
-	echo -e "\nWARNING: WireGuard does not seem to be running."
-	echo "Due to kernel mismatch issues on $OS, WireGuard might work if your system is out of date."
-	echo "You can check if WireGuard is running with: systemctl status wg-quick@$SERVER_WG_NIC"
-	echo 'If you get something like "Cannot find device wg0", please run:'
-	if [[ $OS == 'fedora' ]]; then
-		echo "dnf update -y && reboot"
-	elif [[ $OS == 'centos' ]]; then
-		echo "yum update -y && reboot"
-	fi
-fi
-
-addClient

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -178,10 +178,8 @@ function newClient() {
 	source /etc/wireguard/params
 
 	if [[ $SERVER_PUB_IP =~ .*:.* ]]; then
-		echo "IPv6 Detected"
 		ENDPOINT="[$SERVER_PUB_IP]:$SERVER_PORT"
 	else
-		echo "IPv4 Detected"
 		ENDPOINT="$SERVER_PUB_IP:$SERVER_PORT"
 	fi
 

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -192,11 +192,15 @@ function newClient() {
 	read -rp "Client's WireGuard IPv6 " -e -i "$CLIENT_WG_IPV6" CLIENT_WG_IPV6
 
 	# Adguard DNS by default
-	CLIENT_DNS_1="176.103.130.130"
-	read -rp "First DNS resolver to use for the client: " -e -i "$CLIENT_DNS_1" CLIENT_DNS_1
-
-	CLIENT_DNS_2="176.103.130.131"
-	read -rp "Second DNS resolver to use for the client: " -e -i "$CLIENT_DNS_2" CLIENT_DNS_2
+	until [[ $CLIENT_DNS_1 =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
+		read -rp "First DNS resolver to use for the client: " -e -i 176.103.130.130 CLIENT_DNS_1
+	done
+	until [[ $CLIENT_DNS_2 =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
+		read -rp "Second DNS resolver to use for the client (optional): " -e -i 176.103.130.131 CLIENT_DNS_2
+		if [[ $CLIENT_DNS_2 == "" ]]; then
+			CLIENT_DNS_2=$CLIENT_DNS_1
+		fi
+	done
 
 	CLIENT_NAME=$(
 		head /dev/urandom | tr -dc A-Za-z0-9 | head -c 10

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -69,11 +69,13 @@ function installWireGuard() {
 	SERVER_WG_NIC="wg0"
 	read -rp "WireGuard interface name: " -e -i "$SERVER_WG_NIC" SERVER_WG_NIC
 
-	SERVER_WG_IPV4="10.66.66.1"
-	read -rp "Server's WireGuard IPv4: " -e -i "$SERVER_WG_IPV4" SERVER_WG_IPV4
+	until [[ "$SERVER_WG_IPV4" =~ ^([0-9]{1,3}\.){3}1$ ]]; do
+		read -rp "Server's WireGuard IPv4 [x.x.x.1]: " -e -i 10.66.66.1 SERVER_WG_IPV4
+	done
 
-	SERVER_WG_IPV6="fd42:42:42::1"
-	read -rp "Server's WireGuard IPv6: " -e -i "$SERVER_WG_IPV6" SERVER_WG_IPV6
+	until [[ "$SERVER_WG_IPV6" =~ ^([a-f0-9]{1,4}:){3,4}:1$ ]]; do
+		read -rp "Server's WireGuard IPv6 [x:x:x::1]: " -e -i fd42:42:42::1 SERVER_WG_IPV6
+	done
 
 	# Generate random number within private ports range
 	RANDOM_PORT=$(shuf -i49152-65535 -n1)
@@ -186,11 +188,11 @@ function newClient() {
 	fi
 
 	until [[ "$CLIENT_WG_IPV4" =~ ^([0-9]{1,3}\.?){4}$ ]]; do
-		read -rp "Client's WireGuard IPv4: " -e -i "${SERVER_WG_IPV4: : -1}"2 CLIENT_WG_IPV4
+		read -rp "Client's WireGuard IPv4: " -e -i "${SERVER_WG_IPV4::-1}"2 CLIENT_WG_IPV4
 	done
 
 	until [[ "$CLIENT_WG_IPV6" =~ ^([a-f0-9]{1,4}:?:?){3,5} ]]; do
-		read -rp "Client's WireGuard IPv6 : " -e -i "${SERVER_WG_IPV6: : -1}"2 CLIENT_WG_IPV6
+		read -rp "Client's WireGuard IPv6 : " -e -i "${SERVER_WG_IPV6::-1}"2 CLIENT_WG_IPV6
 	done
 
 	# Adguard DNS by default

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -247,8 +247,8 @@ function newClient() {
 	CLIENT_PRE_SHARED_KEY=$(wg genpsk)
 
 	# Home directory of the user, where the client configuration will be written
-	if [ -e "/home/$CLIENT" ]; then # if $1 is a user name
-		HOME_DIR="/home/$CLIENT"
+	if [ -e "/home/${CLIENT_NAME}" ]; then # if $1 is a user name
+		HOME_DIR="/home/${CLIENT_NAME}"
 	elif [ "${SUDO_USER}" ]; then # if not, use SUDO_USER
 		HOME_DIR="/home/${SUDO_USER}"
 	else # if not SUDO_USER, use /root

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -137,7 +137,7 @@ function installWireGuard() {
 		dnf install -y wireguard-tools iptables qrencode
 	elif [[ "${OS}" == 'centos' ]]; then
 		curl -Lo /etc/yum.repos.d/wireguard.repo https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
-		yum -y install epel-release
+		yum -y install epel-release kernel kernel-devel kernel-headers
 		yum -y install wireguard-dkms wireguard-tools iptables qrencode
 	elif [[ "${OS}" == 'arch' ]]; then
 		pacman -S --noconfirm linux-headers
@@ -197,7 +197,7 @@ net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
 	# Warn user about kernel version mismatch with headers
 	if [[ "${OS}" =~ (fedora|centos) ]] && [[ "${WG_RUNNING}" -ne 0 ]]; then
 		echo -e "\nWARNING: WireGuard does not seem to be running."
-		echo "Due to kernel mismatch issues on ${OS}, WireGuard might work if your system is out of date."
+		echo "Due to kernel mismatch issues on ${OS}, WireGuard might not work if your system is out of date."
 		echo "You can check if WireGuard is running with: systemctl status wg-quick@${SERVER_WG_NIC}"
 		echo 'If you get something like "Cannot find device wg0", please run:'
 		if [[ "${OS}" == 'fedora' ]]; then

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -54,9 +54,13 @@ function installWireGuard() {
 	echo "I need to ask you a few questions before starting the setup."
 	echo "You can leave the default options and just press enter if you are ok with them."
 
-	# Detect public IPv4 address and pre-fill for the user
-	SERVER_PUB_IPV4=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)
-	read -rp "IPv4 or IPv6 public address: " -e -i "$SERVER_PUB_IPV4" SERVER_PUB_IP
+	# Detect public IPv4 or IPv6 address and pre-fill for the user
+	SERVER_PUB_IP=$(ip -4 addr | sed -ne 's|^.* inet \([^/]*\)/.* scope global.*$|\1|p' | head -1)
+	if [[ -z $SERVER_PUB_IP ]]; then
+		# Detect public IPv6 address
+		SERVER_PUB_IP=$(ip -6 addr | sed -ne 's|^.* inet6 \([^/]*\)/.* scope global.*$|\1|p' | head -1)
+	fi
+	read -rp "IPv4 or IPv6 public address: " -e -i "$SERVER_PUB_IP" SERVER_PUB_IP
 
 	# Detect public interface and pre-fill for the user
 	SERVER_PUB_NIC="$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)"

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -185,11 +185,13 @@ function newClient() {
 		ENDPOINT="$SERVER_PUB_IP:$SERVER_PORT"
 	fi
 
-	CLIENT_WG_IPV4="10.66.66.2"
-	read -rp "Client's WireGuard IPv4 " -e -i "$CLIENT_WG_IPV4" CLIENT_WG_IPV4
+	until [[ "$CLIENT_WG_IPV4" =~ ^([0-9]{1,3}\.?){4}$ ]]; do
+		read -rp "Client's WireGuard IPv4: " -e -i 10.66.66.2 CLIENT_WG_IPV4
+	done
 
-	CLIENT_WG_IPV6="fd42:42:42::2"
-	read -rp "Client's WireGuard IPv6 " -e -i "$CLIENT_WG_IPV6" CLIENT_WG_IPV6
+	until [[ "$CLIENT_WG_IPV6" =~ ^([a-f0-9]{1,4}:?:?){3,5} ]]; do
+		read -rp "Client's WireGuard IPv6 : " -e -i fd42:42:42::2 CLIENT_WG_IPV6
+	done
 
 	# Adguard DNS by default
 	until [[ $CLIENT_DNS_1 =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -92,6 +92,11 @@ function installQuestions() {
 	until [[ $SERVER_PORT =~ ^[0-9]+$ ]] && [ "$SERVER_PORT" -ge 1 ] && [ "$SERVER_PORT" -le 65535 ]; do
 		read -rp "Server's WireGuard port [1-65535]: " -e -i "$RANDOM_PORT" SERVER_PORT
 	done
+
+	echo ""
+	echo "Okay, that was all I needed. We are ready to setup your WireGuard server now."
+	echo "You will be able to generate a client at the end of the installation."
+	read -n1 -r -p "Press any key to continue..."
 }
 
 function installWireGuard() {

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -52,7 +52,7 @@ function initialCheck() {
 	checkOS
 }
 
-function installWireGuard() {
+function installQuestions() {
 	echo "Welcome to the WireGuard installer!"
 	echo "The git repository is available at: https://github.com/angristan/wireguard-install"
 	echo ""
@@ -92,6 +92,11 @@ function installWireGuard() {
 	until [[ $SERVER_PORT =~ ^[0-9]+$ ]] && [ "$SERVER_PORT" -ge 1 ] && [ "$SERVER_PORT" -le 65535 ]; do
 		read -rp "Server's WireGuard port [1-65535]: " -e -i "$RANDOM_PORT" SERVER_PORT
 	done
+}
+
+function installWireGuard() {
+	# Run setup questions first
+	installQuestions
 
 	# Install WireGuard tools and module
 	if [[ $OS == 'ubuntu' ]]; then

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -63,8 +63,10 @@ function installWireGuard() {
 	read -rp "IPv4 or IPv6 public address: " -e -i "$SERVER_PUB_IP" SERVER_PUB_IP
 
 	# Detect public interface and pre-fill for the user
-	SERVER_PUB_NIC="$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)"
-	read -rp "Public interface: " -e -i "$SERVER_PUB_NIC" SERVER_PUB_NIC
+	SERVER_NIC="$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)"
+	until [[ "$SERVER_PUB_NIC" =~ ^[a-zA-Z0-9_]+$ ]]; do
+		read -rp "Public interface: " -e -i "$SERVER_NIC" SERVER_PUB_NIC
+	done
 
 	until [[ "$SERVER_WG_NIC" =~ ^[a-zA-Z0-9_]+$ ]]; do
 		read -rp "WireGuard interface name: " -e -i wg0 SERVER_WG_NIC

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -118,8 +118,6 @@ SERVER_PORT=$SERVER_PORT
 SERVER_PRIV_KEY=$SERVER_PRIV_KEY
 SERVER_PUB_KEY=$SERVER_PUB_KEY" >/etc/wireguard/params
 
-	source /etc/wireguard/params
-
 	# Add server interface
 	echo "[Interface]
 Address = $SERVER_WG_IPV4/24,$SERVER_WG_IPV6/64

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -226,15 +226,34 @@ AllowedIPs = $CLIENT_WG_IPV4/32,$CLIENT_WG_IPV6/128" >>"/etc/wireguard/$SERVER_W
 	echo "It is also available in $HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
 }
 
-if [[ $1 == "add-client" ]]; then
-	if [[ -e /etc/wireguard/params ]]; then
+function manageMenu() {
+	echo "Welcome to WireGuard-install!"
+	echo "The git repository is available at: https://github.com/angristan/wireguard-install"
+	echo ""
+	echo "It looks like WireGuard is already installed."
+	echo ""
+	echo "What do you want to do?"
+	echo "   1) Add a new user"
+	echo "   2) Exit"
+	until [[ $MENU_OPTION =~ ^[1-2]$ ]]; do
+		read -rp "Select an option [1-2]: " MENU_OPTION
+	done
+	case $MENU_OPTION in
+	1)
 		addClient
+		;;
+	2)
 		exit 0
-	else
-		echo "Please install and configure WireGuard first."
-		exit 1
-	fi
-elif [[ -e /etc/wireguard/params ]]; then
-	echo "WireGuard is already installed. Run with 'add-client' to add a client."
-	exit 1
+		;;
+	esac
+}
+
+# Check for root, virt, OS...
+initialCheck
+
+# Check if WireGuard is already installed
+if [[ -e /etc/wireguard/params ]]; then
+	manageMenu
+else
+	installWireGuard
 fi

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -160,11 +160,11 @@ net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
 		fi
 	fi
 
-	addClient
+	newClient
 	echo "If you want to add more clients, you simply need to run this script another time!"
 }
 
-function addClient() {
+function newClient() {
 	# Load params
 	source /etc/wireguard/params
 
@@ -240,7 +240,7 @@ function manageMenu() {
 	done
 	case $MENU_OPTION in
 	1)
-		addClient
+		newClient
 		;;
 	2)
 		exit 0

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -66,8 +66,9 @@ function installWireGuard() {
 	SERVER_PUB_NIC="$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)"
 	read -rp "Public interface: " -e -i "$SERVER_PUB_NIC" SERVER_PUB_NIC
 
-	SERVER_WG_NIC="wg0"
-	read -rp "WireGuard interface name: " -e -i "$SERVER_WG_NIC" SERVER_WG_NIC
+	until [[ "$SERVER_WG_NIC" =~ ^[a-zA-Z0-9_]+$ ]]; do
+		read -rp "WireGuard interface name: " -e -i wg0 SERVER_WG_NIC
+	done
 
 	until [[ "$SERVER_WG_IPV4" =~ ^([0-9]{1,3}\.){3}1$ ]]; do
 		read -rp "Server's WireGuard IPv4 [x.x.x.1]: " -e -i 10.66.66.1 SERVER_WG_IPV4

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -23,6 +23,24 @@ function checkVirt() {
 	fi
 }
 
+function checkOS() {
+	# Check OS version
+	if [[ -e /etc/debian_version ]]; then
+		source /etc/os-release
+		OS=$ID # debian or ubuntu
+	elif [[ -e /etc/fedora-release ]]; then
+		source /etc/os-release
+		OS=$ID
+	elif [[ -e /etc/centos-release ]]; then
+		OS=centos
+	elif [[ -e /etc/arch-release ]]; then
+		OS=arch
+	else
+		echo "Looks like you aren't running this installer on a Debian, Ubuntu, Fedora, CentOS or Arch Linux system"
+		exit 1
+	fi
+}
+
 function addClient() {
 	# Load params
 	source /etc/wireguard/params
@@ -96,22 +114,6 @@ if [[ $1 == "add-client" ]]; then
 	fi
 elif [[ -e /etc/wireguard/params ]]; then
 	echo "WireGuard is already installed. Run with 'add-client' to add a client."
-	exit 1
-fi
-
-# Check OS version
-if [[ -e /etc/debian_version ]]; then
-	source /etc/os-release
-	OS=$ID # debian or ubuntu
-elif [[ -e /etc/fedora-release ]]; then
-	source /etc/os-release
-	OS=$ID
-elif [[ -e /etc/centos-release ]]; then
-	OS=centos
-elif [[ -e /etc/arch-release ]]; then
-	OS=arch
-else
-	echo "Looks like you aren't running this installer on a Debian, Ubuntu, Fedora, CentOS or Arch Linux system"
 	exit 1
 fi
 

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -58,6 +58,7 @@ function installWireGuard() {
 	echo ""
 	echo "I need to ask you a few questions before starting the setup."
 	echo "You can leave the default options and just press enter if you are ok with them."
+	echo ""
 
 	# Detect public IPv4 or IPv6 address and pre-fill for the user
 	SERVER_PUB_IP=$(ip -4 addr | sed -ne 's|^.* inet \([^/]*\)/.* scope global.*$|\1|p' | head -1)
@@ -198,6 +199,7 @@ function newClient() {
 		ENDPOINT="$SERVER_PUB_IP:$SERVER_PORT"
 	fi
 
+	printf "\n"
 	until [[ "$CLIENT_WG_IPV4" =~ ^([0-9]{1,3}\.?){4}$ ]]; do
 		read -rp "Client's WireGuard IPv4: " -e -i "${SERVER_WG_IPV4::-1}"2 CLIENT_WG_IPV4
 	done

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -48,6 +48,11 @@ function initialCheck() {
 }
 
 function installWireGuard() {
+	echo "Welcome to the WireGuard installer!"
+	echo "The git repository is available at: https://github.com/angristan/wireguard-install"
+	echo ""
+	echo "I need to ask you a few questions before starting the setup."
+	echo "You can leave the default options and just press enter if you are ok with them."
 
 	# Detect public IPv4 address and pre-fill for the user
 	SERVER_PUB_IPV4=$(ip addr | grep 'inet' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | head -1)

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -237,6 +237,15 @@ function newClient() {
 	CLIENT_PUB_KEY=$(echo "${CLIENT_PRIV_KEY}" | wg pubkey)
 	CLIENT_PRE_SHARED_KEY=$(wg genpsk)
 
+	# Home directory of the user, where the client configuration will be written
+	if [ -e "/home/$CLIENT" ]; then # if $1 is a user name
+		HOME_DIR="/home/$CLIENT"
+	elif [ "${SUDO_USER}" ]; then # if not, use SUDO_USER
+		HOME_DIR="/home/${SUDO_USER}"
+	else # if not SUDO_USER, use /root
+		HOME_DIR="/root"
+	fi
+
 	# Create client file and add the server as a peer
 	echo "[Interface]
 PrivateKey = ${CLIENT_PRIV_KEY}
@@ -247,7 +256,7 @@ DNS = ${CLIENT_DNS_1},${CLIENT_DNS_2}
 PublicKey = ${SERVER_PUB_KEY}
 PresharedKey = ${CLIENT_PRE_SHARED_KEY}
 Endpoint = ${ENDPOINT}
-AllowedIPs = 0.0.0.0/0,::/0" >>"${HOME}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
+AllowedIPs = 0.0.0.0/0,::/0" >>"${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 
 	# Add the client as a peer to the server
 	echo -e "\n[Peer]
@@ -259,9 +268,9 @@ AllowedIPs = ${CLIENT_WG_IPV4}/32,${CLIENT_WG_IPV6}/128" >>"/etc/wireguard/${SER
 
 	echo -e "\nHere is your client config file as a QR Code:"
 
-	qrencode -t ansiutf8 -l L <"${HOME}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
+	qrencode -t ansiutf8 -l L <"${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 
-	echo "It is also available in ${HOME}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
+	echo "It is also available in ${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 }
 
 function manageMenu() {

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -203,17 +203,11 @@ net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
 	systemctl is-active --quiet "wg-quick@${SERVER_WG_NIC}"
 	WG_RUNNING=$?
 
-	# Warn user about kernel version mismatch with headers
-	if [[ "${OS}" =~ (fedora|centos) ]] && [[ "${WG_RUNNING}" -ne 0 ]]; then
+	# WireGuard might not work if we updated the kernel. Tell the user to reboot
+	if [[ "${WG_RUNNING}" -ne 0 ]]; then
 		echo -e "\nWARNING: WireGuard does not seem to be running."
-		echo "Due to kernel mismatch issues on ${OS}, WireGuard might not work if your system is out of date."
 		echo "You can check if WireGuard is running with: systemctl status wg-quick@${SERVER_WG_NIC}"
-		echo 'If you get something like "Cannot find device wg0", please run:'
-		if [[ "${OS}" == 'fedora' ]]; then
-			echo "dnf update -y && reboot"
-		elif [[ "${OS}" == 'centos' ]]; then
-			echo "yum update -y && reboot"
-		fi
+		echo 'If you get something like "Cannot find device wg0", please reboot!'
 	fi
 
 	newClient

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Secure WireGuard server installer for Debian, Ubuntu, CentOS, Fedora and Arch Linux
+# https://github.com/angristan/wireguard-install
+
 function isRoot() {
 	if [ "$EUID" -ne 0 ]; then
 		echo "You need to run this script as root"

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -4,7 +4,7 @@
 # https://github.com/angristan/wireguard-install
 
 function isRoot() {
-	if [ "$EUID" -ne 0 ]; then
+	if [ "${EUID}" -ne 0 ]; then
 		echo "You need to run this script as root"
 		exit 1
 	fi
@@ -31,11 +31,11 @@ function checkOS() {
 	if [[ -e /etc/debian_version ]]; then
 		# shellcheck disable=SC1091
 		source /etc/os-release
-		OS=$ID # debian or ubuntu
+		OS="${ID}" # debian or ubuntu
 	elif [[ -e /etc/fedora-release ]]; then
 		# shellcheck disable=SC1091
 		source /etc/os-release
-		OS=$ID
+		OS="${ID}"
 	elif [[ -e /etc/centos-release ]]; then
 		OS=centos
 	elif [[ -e /etc/arch-release ]]; then
@@ -62,35 +62,35 @@ function installQuestions() {
 
 	# Detect public IPv4 or IPv6 address and pre-fill for the user
 	SERVER_PUB_IP=$(ip -4 addr | sed -ne 's|^.* inet \([^/]*\)/.* scope global.*$|\1|p' | head -1)
-	if [[ -z $SERVER_PUB_IP ]]; then
+	if [[ -z "${SERVER_PUB_IP}" ]]; then
 		# Detect public IPv6 address
 		SERVER_PUB_IP=$(ip -6 addr | sed -ne 's|^.* inet6 \([^/]*\)/.* scope global.*$|\1|p' | head -1)
 	fi
-	read -rp "IPv4 or IPv6 public address: " -e -i "$SERVER_PUB_IP" SERVER_PUB_IP
+	read -rp "IPv4 or IPv6 public address: " -e -i "${SERVER_PUB_IP}" SERVER_PUB_IP
 
 	# Detect public interface and pre-fill for the user
 	SERVER_NIC="$(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)' | head -1)"
-	until [[ "$SERVER_PUB_NIC" =~ ^[a-zA-Z0-9_]+$ ]]; do
-		read -rp "Public interface: " -e -i "$SERVER_NIC" SERVER_PUB_NIC
+	until [[ "${SERVER_PUB_NIC}" =~ ^[a-zA-Z0-9_]+$ ]]; do
+		read -rp "Public interface: " -e -i "${SERVER_NIC}" SERVER_PUB_NIC
 	done
 
-	until [[ "$SERVER_WG_NIC" =~ ^[a-zA-Z0-9_]+$ ]]; do
+	until [[ "${SERVER_WG_NIC}" =~ ^[a-zA-Z0-9_]+$ ]]; do
 		# shellcheck disable=SC2034
 		read -rp "WireGuard interface name: " -e -i wg0 SERVER_WG_NIC
 	done
 
-	until [[ "$SERVER_WG_IPV4" =~ ^([0-9]{1,3}\.){3}1$ ]]; do
+	until [[ "${SERVER_WG_IPV4}" =~ ^([0-9]{1,3}\.){3}1$ ]]; do
 		read -rp "Server's WireGuard IPv4 [x.x.x.1]: " -e -i 10.66.66.1 SERVER_WG_IPV4
 	done
 
-	until [[ "$SERVER_WG_IPV6" =~ ^([a-f0-9]{1,4}:){3,4}:1$ ]]; do
+	until [[ "${SERVER_WG_IPV6}" =~ ^([a-f0-9]{1,4}:){3,4}:1$ ]]; do
 		read -rp "Server's WireGuard IPv6 [x:x:x::1]: " -e -i fd42:42:42::1 SERVER_WG_IPV6
 	done
 
 	# Generate random number within private ports range
 	RANDOM_PORT=$(shuf -i49152-65535 -n1)
-	until [[ $SERVER_PORT =~ ^[0-9]+$ ]] && [ "$SERVER_PORT" -ge 1 ] && [ "$SERVER_PORT" -le 65535 ]; do
-		read -rp "Server's WireGuard port [1-65535]: " -e -i "$RANDOM_PORT" SERVER_PORT
+	until [[ "${SERVER_PORT}" =~ ^[0-9]+$ ]] && [ "${SERVER_PORT}" -ge 1 ] && [ "${SERVER_PORT}" -le 65535 ]; do
+		read -rp "Server's WireGuard port [1-65535]: " -e -i "${RANDOM_PORT}" SERVER_PORT
 	done
 
 	echo ""
@@ -104,31 +104,31 @@ function installWireGuard() {
 	installQuestions
 
 	# Install WireGuard tools and module
-	if [[ $OS == 'ubuntu' ]]; then
+	if [[ "${OS}" == 'ubuntu' ]]; then
 		apt-get install -y software-properties-common
 		add-apt-repository -y ppa:wireguard/wireguard
 		apt-get update
 		apt-get install -y "linux-headers-$(uname -r)"
 		apt-get install -y wireguard iptables resolvconf qrencode
-	elif [[ $OS == 'debian' ]]; then
+	elif [[ "${OS}" == 'debian' ]]; then
 		echo "deb http://deb.debian.org/debian/ unstable main" >/etc/apt/sources.list.d/unstable.list
 		printf 'Package: *\nPin: release a=unstable\nPin-Priority: 90\n' >/etc/apt/preferences.d/limit-unstable
 		apt update
 		apt-get install -y "linux-headers-$(uname -r)"
 		apt-get install -y wireguard iptables resolvconf qrencode
 		apt-get install -y bc # mitigate https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=956869
-	elif [[ $OS == 'fedora' ]]; then
-		if [[ $VERSION_ID -lt 32 ]]; then
+	elif [[ "${OS}" == 'fedora' ]]; then
+		if [[ "${VERSION_ID}" -lt 32 ]]; then
 			dnf install -y dnf-plugins-core
 			dnf copr enable -y jdoss/wireguard
 			dnf install -y wireguard-dkms
 		fi
 		dnf install -y wireguard-tools iptables qrencode
-	elif [[ $OS == 'centos' ]]; then
+	elif [[ "${OS}" == 'centos' ]]; then
 		curl -Lo /etc/yum.repos.d/wireguard.repo https://copr.fedorainfracloud.org/coprs/jdoss/wireguard/repo/epel-7/jdoss-wireguard-epel-7.repo
 		yum -y install epel-release
 		yum -y install wireguard-dkms wireguard-tools iptables qrencode
-	elif [[ $OS == 'arch' ]]; then
+	elif [[ "${OS}" == 'arch' ]]; then
 		pacman -S --noconfirm linux-headers
 		pacman -S --noconfirm wireguard-tools iptables qrencode
 	fi
@@ -139,33 +139,33 @@ function installWireGuard() {
 	chmod 600 -R /etc/wireguard/
 
 	SERVER_PRIV_KEY=$(wg genkey)
-	SERVER_PUB_KEY=$(echo "$SERVER_PRIV_KEY" | wg pubkey)
+	SERVER_PUB_KEY=$(echo "${SERVER_PRIV_KEY}" | wg pubkey)
 
 	# Save WireGuard settings
-	echo "SERVER_PUB_IP=$SERVER_PUB_IP
-SERVER_PUB_NIC=$SERVER_PUB_NIC
-SERVER_WG_NIC=$SERVER_WG_NIC
-SERVER_WG_IPV4=$SERVER_WG_IPV4
-SERVER_WG_IPV6=$SERVER_WG_IPV6
-SERVER_PORT=$SERVER_PORT
-SERVER_PRIV_KEY=$SERVER_PRIV_KEY
-SERVER_PUB_KEY=$SERVER_PUB_KEY" >/etc/wireguard/params
+	echo "SERVER_PUB_IP=${SERVER_PUB_IP}
+SERVER_PUB_NIC=${SERVER_PUB_NIC}
+SERVER_WG_NIC=${SERVER_WG_NIC}
+SERVER_WG_IPV4=${SERVER_WG_IPV4}
+SERVER_WG_IPV6=${SERVER_WG_IPV6}
+SERVER_PORT=${SERVER_PORT}
+SERVER_PRIV_KEY=${SERVER_PRIV_KEY}
+SERVER_PUB_KEY=${SERVER_PUB_KEY}" >/etc/wireguard/params
 
 	# Add server interface
 	echo "[Interface]
-Address = $SERVER_WG_IPV4/24,$SERVER_WG_IPV6/64
-ListenPort = $SERVER_PORT
-PrivateKey = $SERVER_PRIV_KEY" >"/etc/wireguard/$SERVER_WG_NIC.conf"
+Address = ${SERVER_WG_IPV4}/24,${SERVER_WG_IPV6}/64
+ListenPort = ${SERVER_PORT}
+PrivateKey = ${SERVER_PRIV_KEY}" >"/etc/wireguard/${SERVER_WG_NIC}.conf"
 
 	if [ -x "$(command -v firewall-cmd)" ]; then
-		FIREWALLD_IPV4_ADDRESS=$(echo "$SERVER_WG_IPV4" | cut -d"." -f1-3)".0"
+		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-3)".0"
 		# shellcheck disable=SC2001
-		FIREWALLD_IPV6_ADDRESS=$(echo "$SERVER_WG_IPV6" | sed 's/:[^:]*$/:0/')
-		echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'
-PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
+		FIREWALLD_IPV6_ADDRESS=$(echo "${SERVER_WG_IPV6}" | sed 's/:[^:]*$/:0/')
+		echo "PostUp = firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'
+PostDown = firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
 	else
-		echo "PostUp = iptables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -A FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -A POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE
-PostDown = iptables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; iptables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE; ip6tables -D FORWARD -i $SERVER_WG_NIC -j ACCEPT; ip6tables -t nat -D POSTROUTING -o $SERVER_PUB_NIC -j MASQUERADE" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
+		echo "PostUp = iptables -A FORWARD -i ${SERVER_WG_NIC} -j ACCEPT; iptables -t nat -A POSTROUTING -o ${SERVER_PUB_NIC} -j MASQUERADE; ip6tables -A FORWARD -i ${SERVER_WG_NIC} -j ACCEPT; ip6tables -t nat -A POSTROUTING -o ${SERVER_PUB_NIC} -j MASQUERADE
+PostDown = iptables -D FORWARD -i ${SERVER_WG_NIC} -j ACCEPT; iptables -t nat -D POSTROUTING -o ${SERVER_PUB_NIC} -j MASQUERADE; ip6tables -D FORWARD -i ${SERVER_WG_NIC} -j ACCEPT; ip6tables -t nat -D POSTROUTING -o ${SERVER_PUB_NIC} -j MASQUERADE" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
 	fi
 
 	# Enable routing on the server
@@ -174,22 +174,22 @@ net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
 
 	sysctl --system
 
-	systemctl start "wg-quick@$SERVER_WG_NIC"
-	systemctl enable "wg-quick@$SERVER_WG_NIC"
+	systemctl start "wg-quick@${SERVER_WG_NIC}"
+	systemctl enable "wg-quick@${SERVER_WG_NIC}"
 
 	# Check if WireGuard is running
-	systemctl is-active --quiet "wg-quick@$SERVER_WG_NIC"
+	systemctl is-active --quiet "wg-quick@${SERVER_WG_NIC}"
 	WG_RUNNING=$?
 
 	# Warn user about kernel version mismatch with headers
-	if [[ $OS =~ (fedora|centos) ]] && [[ $WG_RUNNING -ne 0 ]]; then
+	if [[ "${OS}" =~ (fedora|centos) ]] && [[ "${WG_RUNNING}" -ne 0 ]]; then
 		echo -e "\nWARNING: WireGuard does not seem to be running."
-		echo "Due to kernel mismatch issues on $OS, WireGuard might work if your system is out of date."
-		echo "You can check if WireGuard is running with: systemctl status wg-quick@$SERVER_WG_NIC"
+		echo "Due to kernel mismatch issues on ${OS}, WireGuard might work if your system is out of date."
+		echo "You can check if WireGuard is running with: systemctl status wg-quick@${SERVER_WG_NIC}"
 		echo 'If you get something like "Cannot find device wg0", please run:'
-		if [[ $OS == 'fedora' ]]; then
+		if [[ "${OS}" == 'fedora' ]]; then
 			echo "dnf update -y && reboot"
-		elif [[ $OS == 'centos' ]]; then
+		elif [[ "${OS}" == 'centos' ]]; then
 			echo "yum update -y && reboot"
 		fi
 	fi
@@ -206,22 +206,22 @@ function newClient() {
 	ENDPOINT="${SERVER_PUB_IP}:${SERVER_PORT}"
 
 	printf "\n"
-	until [[ "$CLIENT_WG_IPV4" =~ ^([0-9]{1,3}\.?){4}$ ]]; do
+	until [[ "${CLIENT_WG_IPV4}" =~ ^([0-9]{1,3}\.?){4}$ ]]; do
 		read -rp "Client's WireGuard IPv4: " -e -i "${SERVER_WG_IPV4::-1}"2 CLIENT_WG_IPV4
 	done
 
-	until [[ "$CLIENT_WG_IPV6" =~ ^([a-f0-9]{1,4}:?:?){3,5} ]]; do
+	until [[ "${CLIENT_WG_IPV6}" =~ ^([a-f0-9]{1,4}:?:?){3,5} ]]; do
 		read -rp "Client's WireGuard IPv6 : " -e -i "${SERVER_WG_IPV6::-1}"2 CLIENT_WG_IPV6
 	done
 
 	# Adguard DNS by default
-	until [[ $CLIENT_DNS_1 =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
+	until [[ "${CLIENT_DNS_1}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
 		read -rp "First DNS resolver to use for the client: " -e -i 176.103.130.130 CLIENT_DNS_1
 	done
-	until [[ $CLIENT_DNS_2 =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
+	until [[ "${CLIENT_DNS_2}" =~ ^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$ ]]; do
 		read -rp "Second DNS resolver to use for the client (optional): " -e -i 176.103.130.131 CLIENT_DNS_2
-		if [[ $CLIENT_DNS_2 == "" ]]; then
-			CLIENT_DNS_2=$CLIENT_DNS_1
+		if [[ "${CLIENT_DNS_2}" == "" ]]; then
+			CLIENT_DNS_2="${CLIENT_DNS_1}"
 		fi
 	done
 
@@ -232,34 +232,34 @@ function newClient() {
 
 	# Generate key pair for the client
 	CLIENT_PRIV_KEY=$(wg genkey)
-	CLIENT_PUB_KEY=$(echo "$CLIENT_PRIV_KEY" | wg pubkey)
+	CLIENT_PUB_KEY=$(echo "${CLIENT_PRIV_KEY}" | wg pubkey)
 	CLIENT_PRE_SHARED_KEY=$(wg genpsk)
 
 	# Create client file and add the server as a peer
 	echo "[Interface]
-PrivateKey = $CLIENT_PRIV_KEY
-Address = $CLIENT_WG_IPV4/24,$CLIENT_WG_IPV6/64
-DNS = $CLIENT_DNS_1,$CLIENT_DNS_2
+PrivateKey = ${CLIENT_PRIV_KEY}
+Address = ${CLIENT_WG_IPV4}/24,${CLIENT_WG_IPV6}/64
+DNS = ${CLIENT_DNS_1},${CLIENT_DNS_2}
 
 [Peer]
-PublicKey = $SERVER_PUB_KEY
-PresharedKey = $CLIENT_PRE_SHARED_KEY
-Endpoint = $ENDPOINT
-AllowedIPs = 0.0.0.0/0,::/0" >>"$HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
+PublicKey = ${SERVER_PUB_KEY}
+PresharedKey = ${CLIENT_PRE_SHARED_KEY}
+Endpoint = ${ENDPOINT}
+AllowedIPs = 0.0.0.0/0,::/0" >>"${HOME}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 
 	# Add the client as a peer to the server
 	echo -e "\n[Peer]
-PublicKey = $CLIENT_PUB_KEY
-PresharedKey = $CLIENT_PRE_SHARED_KEY
-AllowedIPs = $CLIENT_WG_IPV4/32,$CLIENT_WG_IPV6/128" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
+PublicKey = ${CLIENT_PUB_KEY}
+PresharedKey = ${CLIENT_PRE_SHARED_KEY}
+AllowedIPs = ${CLIENT_WG_IPV4}/32,${CLIENT_WG_IPV6}/128" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
 
-	systemctl restart "wg-quick@$SERVER_WG_NIC"
+	systemctl restart "wg-quick@${SERVER_WG_NIC}"
 
 	echo -e "\nHere is your client config file as a QR Code:"
 
-	qrencode -t ansiutf8 -l L <"$HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
+	qrencode -t ansiutf8 -l L <"${HOME}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 
-	echo "It is also available in $HOME/$SERVER_WG_NIC-client-$CLIENT_NAME.conf"
+	echo "It is also available in ${HOME}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 }
 
 function manageMenu() {
@@ -271,10 +271,10 @@ function manageMenu() {
 	echo "What do you want to do?"
 	echo "   1) Add a new user"
 	echo "   2) Exit"
-	until [[ $MENU_OPTION =~ ^[1-2]$ ]]; do
+	until [[ "${MENU_OPTION}" =~ ^[1-2]$ ]]; do
 		read -rp "Select an option [1-2]: " MENU_OPTION
 	done
-	case $MENU_OPTION in
+	case "${MENU_OPTION}" in
 	1)
 		newClient
 		;;

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -203,11 +203,7 @@ function newClient() {
 	# shellcheck disable=SC1091
 	source /etc/wireguard/params
 
-	if [[ $SERVER_PUB_IP =~ .*:.* ]]; then
-		ENDPOINT="[$SERVER_PUB_IP]:$SERVER_PORT"
-	else
-		ENDPOINT="$SERVER_PUB_IP:$SERVER_PORT"
-	fi
+	ENDPOINT="${SERVER_PUB_IP}:${SERVER_PORT}"
 
 	printf "\n"
 	until [[ "$CLIENT_WG_IPV4" =~ ^([0-9]{1,3}\.?){4}$ ]]; do

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -170,7 +170,7 @@ Address = ${SERVER_WG_IPV4}/24,${SERVER_WG_IPV6}/64
 ListenPort = ${SERVER_PORT}
 PrivateKey = ${SERVER_PRIV_KEY}" >"/etc/wireguard/${SERVER_WG_NIC}.conf"
 
-	if [ -x "$(command -v firewall-cmd)" ]; then
+	if pgrep firewalld; then
 		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-3)".0"
 		# shellcheck disable=SC2001
 		FIREWALLD_IPV6_ADDRESS=$(echo "${SERVER_WG_IPV6}" | sed 's/:[^:]*$/:0/')

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -29,9 +29,11 @@ function checkVirt() {
 function checkOS() {
 	# Check OS version
 	if [[ -e /etc/debian_version ]]; then
+		# shellcheck disable=SC1091
 		source /etc/os-release
 		OS=$ID # debian or ubuntu
 	elif [[ -e /etc/fedora-release ]]; then
+		# shellcheck disable=SC1091
 		source /etc/os-release
 		OS=$ID
 	elif [[ -e /etc/centos-release ]]; then
@@ -72,6 +74,7 @@ function installWireGuard() {
 	done
 
 	until [[ "$SERVER_WG_NIC" =~ ^[a-zA-Z0-9_]+$ ]]; do
+		# shellcheck disable=SC2034
 		read -rp "WireGuard interface name: " -e -i wg0 SERVER_WG_NIC
 	done
 
@@ -145,6 +148,7 @@ PrivateKey = $SERVER_PRIV_KEY" >"/etc/wireguard/$SERVER_WG_NIC.conf"
 
 	if [ -x "$(command -v firewall-cmd)" ]; then
 		FIREWALLD_IPV4_ADDRESS=$(echo "$SERVER_WG_IPV4" | cut -d"." -f1-3)".0"
+		# shellcheck disable=SC2001
 		FIREWALLD_IPV6_ADDRESS=$(echo "$SERVER_WG_IPV6" | sed 's/:[^:]*$/:0/')
 		echo "PostUp = firewall-cmd --add-port $SERVER_PORT/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'
 PostDown = firewall-cmd --remove-port $SERVER_PORT/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=$FIREWALLD_IPV4_ADDRESS/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=$FIREWALLD_IPV6_ADDRESS/24 masquerade'" >>"/etc/wireguard/$SERVER_WG_NIC.conf"
@@ -185,6 +189,7 @@ net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
 
 function newClient() {
 	# Load params
+	# shellcheck disable=SC1091
 	source /etc/wireguard/params
 
 	if [[ $SERVER_PUB_IP =~ .*:.* ]]; then


### PR DESCRIPTION
I followed the style of the openvpn-install repository and used some of its code. Thanks to everyone that [contributed](https://github.com/angristan/openvpn-install/blame/master/openvpn-install.sh) there.

The other additions are:
- cleaned some minor code
- use IPv6 if IPv4 isn't available
- add input validations, fixes #86 . The regex rules I used **need improvements**
  - assign secondary DNS to primary DNS value if it's empty. I know #75 was already open for this so I added @chrislewicki as co-author. If this isn't OK for someone, I can remove the commit. Fixes #68 
- use `$SERVER_WG_IPV4` and `$SERVER_WG_IPV6` when suggesting the client IP
- save user DNS to `params` file and apply it to all clients, removing support for customizing DNS for individual clients. If this is a problem we can add again the code to allow customization but maybe use the sourced DNS as a suggestion for clients that need a different one
- add shellcheck ignores, needed for IDE that have shellcheck support
- escaped variables to `"${var}"` style
- updated README to reflect changes
- fixed the kernel mismatch issue on CentOS by updating the kernel https://github.com/angristan/wireguard-install/issues/95#issuecomment-653696198. Fedora might need this change too but I can't test now.
- Use `firewall-cmd` only if `firewalld` is running. Fixes #95 
- Fix the client's subnet mask. Fixes #87 
- Save the client configuration in the correct `$HOME`. Fixes #96 

Tested on Debian 10