### PR TITLE
Upgrade system prior to wg installation

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -121,15 +121,15 @@ function installWireGuard() {
 
 	# Install WireGuard tools and module
 	if [[ ${OS} == 'ubuntu' ]]; then
-		apt-get update
-		apt-get install -y wireguard iptables resolvconf qrencode
+		apt-get update && apt-get -y upgrade
+		apt-get install -y linux-headers-$(uname -r) wireguard iptables resolvconf qrencode
 	elif [[ ${OS} == 'debian' ]]; then
 		if ! grep -rqs "^deb .* buster-backports" /etc/apt/; then
 			echo "deb http://deb.debian.org/debian buster-backports main" >/etc/apt/sources.list.d/backports.list
 			apt-get update
 		fi
-		apt update
-		apt-get install -y iptables resolvconf qrencode
+		apt update && apt-get -y upgrade
+		apt-get install -y iptables resolvconf qrencode linux-headers-$(uname -r)
 		apt-get install -y -t buster-backports wireguard
 	elif [[ ${OS} == 'fedora' ]]; then
 		if [[ ${VERSION_ID} -lt 32 ]]; then


### PR DESCRIPTION
Upgrade system and install kernel headers prior to wireguard installation.
On Ubuntu 18.04 without system upgrade, wireguard was unable to start with below error:

```
ip link add dev wg0 type wireguard
Error: Unknown device type.
```

```
modprobe wireguard
modprobe: FATAL: Module wireguard not found in directory 

```
```
Make log:
DKMS make.log for wireguard-1.0.20200611 for kernel 4.15.0-101-generic (x86_64)
Thu Aug 27 14:55:47 CST 2020
make: Entering directory '/usr/src/linux-headers-4.15.0-101-generic'
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/main.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/noise.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/device.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/peer.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/timers.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/queueing.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/send.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/receive.o
  CC [M]  /var/lib/dkms/wireguard/1.0.20200611/build/socket.o
/var/lib/dkms/wireguard/1.0.20200611/build/socket.c: In function 'send6':
/var/lib/dkms/wireguard/1.0.20200611/build/socket.c:139:20: error: 'const struct ipv6_stub' has no member named 'ipv6_dst_lookup_flow'; did you mean $
   dst = ipv6_stub->ipv6_dst_lookup_flow(sock_net(sock), sock, &fl,
                    ^~~~~~~~~~~~~~~~~~~~
                    ipv6_dst_lookup
scripts/Makefile.build:330: recipe for target '/var/lib/dkms/wireguard/1.0.20200611/build/socket.o' failed
make[1]: *** [/var/lib/dkms/wireguard/1.0.20200611/build/socket.o] Error 1
Makefile:1577: recipe for target '_module_/var/lib/dkms/wireguard/1.0.20200611/build' failed
make: *** [_module_/var/lib/dkms/wireguard/1.0.20200611/build] Error 2
make: Leaving directory '/usr/src/linux-headers-4.15.0-101-generic'
```