### PR TITLE
Arch LTS-kernel

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -143,7 +143,12 @@ function installWireGuard() {
 		yum -y install epel-release kernel kernel-devel kernel-headers
 		yum -y install wireguard-dkms wireguard-tools iptables qrencode
 	elif [[ ${OS} == 'arch' ]]; then
-		pacman -S --noconfirm linux-headers
+		ARCH_LTS_KERNEL=$(pacman -Qs linux-lts)
+		if [[ -n ${ARCH_LTS_KERNEL} ]]; then
+			pacman -S --noconfirm linux-lts-headers
+		else
+			pacman -S --noconfirm linux-headers
+		fi
 		pacman -S --noconfirm wireguard-tools iptables qrencode
 	fi
 

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -143,8 +143,9 @@ function installWireGuard() {
 		yum -y install epel-release kernel kernel-devel kernel-headers
 		yum -y install wireguard-dkms wireguard-tools iptables qrencode
 	elif [[ ${OS} == 'arch' ]]; then
-		ARCH_LTS_KERNEL=$(pacman -Qs linux-lts)
-		if [[ -n ${ARCH_LTS_KERNEL} ]]; then
+		# Check if current running kernel is LTS
+		ARCH_KERNEL_RELEASE=$(uname -r)
+		if [[ ${ARCH_KERNEL_RELEASE} == *lts* ]]; then
 			pacman -S --noconfirm linux-lts-headers
 		else
 			pacman -S --noconfirm linux-headers


### PR DESCRIPTION
If linux-lts is installed then the suitable headers are in linux-lts-headers package.