### PR TITLE
Forbid client names exceeding 15 chars in length

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -79,7 +79,7 @@ function installQuestions() {
 		read -rp "Public interface: " -e -i "${SERVER_NIC}" SERVER_PUB_NIC
 	done
 
-	until [[ ${SERVER_WG_NIC} =~ ^[a-zA-Z0-9_]+$ ]]; do
+	until [[ ${SERVER_WG_NIC} =~ ^[a-zA-Z0-9_]+$ && ${#SERVER_WG_NIC} -lt 16 ]]; do
 		read -rp "WireGuard interface name: " -e -i wg0 SERVER_WG_NIC
 	done
 

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -219,9 +219,9 @@ function newClient() {
 
 	echo ""
 	echo "Tell me a name for the client."
-	echo "The name must consist of alphanumeric character. It may also include an underscore or a dash."
+	echo "The name must consist of alphanumeric character. It may also include an underscore or a dash and can't exceed 15 chars."
 
-	until [[ ${CLIENT_NAME} =~ ^[a-zA-Z0-9_-]+$ && ${CLIENT_EXISTS} == '0' ]]; do
+	until [[ ${CLIENT_NAME} =~ ^[a-zA-Z0-9_-]+$ && ${CLIENT_EXISTS} == '0' && ${#CLIENT_NAME} < 16 ]]; do
 		read -rp "Client name: " -e CLIENT_NAME
 		CLIENT_EXISTS=$(grep -c -E "^### Client ${CLIENT_NAME}\$" "/etc/wireguard/${SERVER_WG_NIC}.conf")
 

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -221,7 +221,7 @@ function newClient() {
 	echo "Tell me a name for the client."
 	echo "The name must consist of alphanumeric character. It may also include an underscore or a dash and can't exceed 15 chars."
 
-	until [[ ${CLIENT_NAME} =~ ^[a-zA-Z0-9_-]+$ && ${CLIENT_EXISTS} == '0' && ${#CLIENT_NAME} < 16 ]]; do
+	until [[ ${CLIENT_NAME} =~ ^[a-zA-Z0-9_-]+$ && ${CLIENT_EXISTS} == '0' && ${#CLIENT_NAME} -lt 16 ]]; do
 		read -rp "Client name: " -e CLIENT_NAME
 		CLIENT_EXISTS=$(grep -c -E "^### Client ${CLIENT_NAME}\$" "/etc/wireguard/${SERVER_WG_NIC}.conf")
 


### PR DESCRIPTION
Linux interface names seem to be limited to 15 characters, as referenced [here (IFNAMSIZ)](https://www.gnu.org/software/libc/manual/html_node/Interface-Naming.html) and [in the kernel](https://elixir.bootlin.com/linux/v5.6/source/include/uapi/linux/if.h#L33). So, 16 minus "its terminating zero byte"

This becomes an issue once you want to use `wg-quick` with a `CONFIG_NAME` longer than 15 chars. You will receive this error:

```bash
$ wg-quick up conf-too-long-cant-you-see.conf
$ wg-quick: The config file must be a valid interface name, followed by .conf
```

This PR forbids `CLIENT_NAME`s longer than 15 characters. 

Tested on ubuntu 20.04.

Cheers! 