### PR TITLE
Revert "Fix client subnet mask"

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -286,7 +286,7 @@ function newClient() {
 	# Create client file and add the server as a peer
 	echo "[Interface]
 PrivateKey = ${CLIENT_PRIV_KEY}
-Address = ${CLIENT_WG_IPV4}/32,${CLIENT_WG_IPV6}/128
+Address = ${CLIENT_WG_IPV4}/24,${CLIENT_WG_IPV6}/64
 DNS = ${CLIENT_DNS_1},${CLIENT_DNS_2}
 
 [Peer]


### PR DESCRIPTION
This commit accidentally breaks IPv6 when several clients are connected at the same time, and it is more correct to use `/24` and `/64` subnets as it is used in WireGuard examples (for example,  [Basic Usage]).

[Basic Usage]: https://www.wireguard.com/papers/wireguard.pdf.