### PR TITLE
Fix unnecessary reinstall of packages

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -147,11 +147,11 @@ function installWireGuard() {
 		# Check if current running kernel is LTS
 		ARCH_KERNEL_RELEASE=$(uname -r)
 		if [[ ${ARCH_KERNEL_RELEASE} == *lts* ]]; then
-			pacman -S --noconfirm linux-lts-headers
+			pacman -S --needed --noconfirm linux-lts-headers
 		else
-			pacman -S --noconfirm linux-headers
+			pacman -S --needed --noconfirm linux-headers
 		fi
-		pacman -S --noconfirm wireguard-tools iptables qrencode
+		pacman -S --needed --noconfirm wireguard-tools iptables qrencode
 	fi
 
 	# Make sure the directory exists (this does not seem the be the case on fedora)


### PR DESCRIPTION
On Arch Linux, already installed packages are reinstalled during the initial setup. The `--needed` flag skips packages that are already installed and up-to-date.