### PR TITLE
you killed my keys :(

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -369,8 +369,8 @@ function uninstallWg() {
 		elif [[ ${OS} == 'arch' ]]; then
 			pacman -Rs --noconfirm wireguard-tools qrencode
 		fi
-
-		rm -rf /etc/wireguard
+		
+		#rm -rf /etc/wireguard
 		rm -f /etc/sysctl.d/wg.conf
 
 		# Reload sysctl


### PR DESCRIPTION
I needed to reinstall the wireguard and without warning all the keys were demolished: ( This is bad!
At least about this you need to ask the user additionally. At least remove the -f switch from rm (`rm -r /etc/wireguard`)