### PR TITLE
Enable installing on LXC containers if Wireguard kernel Module exists.

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -156,8 +156,8 @@ function installWireGuard() {
 			apt-get install -y -t buster-backports wireguard
 		fi
 
-	elif [[ ${OS} == 'fedora' ]] && [[ $Container != 1 ]]; then
-		if [[ ${VERSION_ID} -lt 32 ]]; then
+	elif [[ ${OS} == 'fedora' ]]; then
+		if [[ ${VERSION_ID} -lt 32 ]] && [[ $Container != 1 ]]; then
 			dnf install -y dnf-plugins-core
 			dnf copr enable -y jdoss/wireguard
 			dnf install -y wireguard-dkms


### PR DESCRIPTION
This is considered beta. I added a test of creating interface wg999 as WireGuard. If successful, then the installer can proceed.

I tested it on my LXD machine with Centos 7,8, Fedora 32,33, Ubuntu 20.04, and Archlinux unprivileged containers. 

Running on LXD 4.10 on Ubuntu 20.04.