### PR TITLE
Remove unneeded packages on Arch Linux

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -148,14 +148,7 @@ function installWireGuard() {
 		fi
 		yum -y install kmod-wireguard wireguard-tools iptables qrencode
 	elif [[ ${OS} == 'arch' ]]; then
-		# Check if current running kernel is LTS
-		ARCH_KERNEL_RELEASE=$(uname -r)
-		if [[ ${ARCH_KERNEL_RELEASE} == *lts* ]]; then
-			pacman -S --needed --noconfirm linux-lts-headers
-		else
-			pacman -S --needed --noconfirm linux-headers
-		fi
-		pacman -S --needed --noconfirm wireguard-tools iptables qrencode
+		pacman -S --needed --noconfirm wireguard-tools qrencode
 	fi
 
 	# Make sure the directory exists (this does not seem the be the case on fedora)


### PR DESCRIPTION
I have removed 3 packages for Arch Linux installation because:

- Linux headers are not needed for building WireGuard kernel module, it is already included on the kernel.
- "iptables" is a required dependency of "base" package which is installed on every Arch Linux installation.