### PR TITLE
Install error on debian 10

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -132,6 +132,7 @@ function installWireGuard() {
 			apt-get update
 		fi
 		apt update
+		apt-get install -y wireguard-dkms
 		apt-get install -y iptables resolvconf qrencode
 		apt-get install -y -t buster-backports wireguard
 	elif [[ ${OS} == 'fedora' ]]; then


### PR DESCRIPTION
Without this, it can be installed on a newly installed version of debian 10. One line is enough to fix it.