### PR TITLE
Fix installation on Raspbian systems

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -40,7 +40,7 @@ function checkOS() {
 				echo "Your version of Debian (${VERSION_ID}) is not supported. Please use Debian 10 Buster or later"
 				exit 1
 			fi
-			OS=debian
+			OS=debian # overwrite if raspbian
 		fi
 	elif [[ -e /etc/fedora-release ]]; then
 		source /etc/os-release

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -40,6 +40,7 @@ function checkOS() {
 				echo "Your version of Debian (${VERSION_ID}) is not supported. Please use Debian 10 Buster or later"
 				exit 1
 			fi
+			OS=debian
 		fi
 	elif [[ -e /etc/fedora-release ]]; then
 		source /etc/os-release


### PR DESCRIPTION
This PR fixes https://github.com/angristan/wireguard-install/issues/263
Since Raspbian and Debian share OS version ID in /etc/os-release, and there are the same wireguard packages in both distros, it's OK to consider them the same OS further down in the script.