### PR TITLE
remove default char "n" from uninstall step

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -362,7 +362,8 @@ function revokeClient() {
 
 function uninstallWg() {
 	echo ""
-	read -rp "Do you really want to remove WireGuard? [y/n]: " -e -i n REMOVE
+	read -rp "Do you really want to remove WireGuard? [y/n]: " -e REMOVE 
+	REMOVE=${REMOVE:-n}
 	if [[ $REMOVE == 'y' ]]; then
 		checkOS
 


### PR DESCRIPTION
close Remove default value "n" when uninstalling #369

The character "n" is no longer in the prompt but it is still the default value.