### PR TITLE
Add support for custom ALLOWED_IPS

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -117,9 +117,8 @@ function installQuestions() {
 	done
 	
 	#Allowed IPs
-	until [[ ${ALLOWED_IPS} =~ ^.*$ ]]; do
-		read -rp "Allowed IPs list:
- " -e -i "0.0.0.0/0, ::/0, 128.0.0.0/1" ALLOWED_IPS
+	until [[ ${ALLOWED_IPS} =~ ^.+$ ]]; do
+		read -rp "Allowed IPs list: " -e -i '0.0.0.0/0, ::/0, 128.0.0.0/1' ALLOWED_IPS
  		if [[ ${ALLOWED_IPS} == "" ]]; then
 			ALLOWED_IPS="0.0.0.0/0, ::/0, 128.0.0.0/1"
 		fi

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -118,7 +118,7 @@ function installQuestions() {
 	
 	#Allowed IPs
 	until [[ ${ALLOWED_IPS} =~ ^.+$ ]]; do
-		read -rp "Allowed IPs list: " -e -i '0.0.0.0/0, ::/0, 128.0.0.0/1' ALLOWED_IPS
+		read -rp "Allowed IPs list: " -e -i '0.0.0.0/1, 128.0.0.0/1, ::/0,' ALLOWED_IPS
  		if [[ ${ALLOWED_IPS} == "" ]]; then
 			ALLOWED_IPS="0.0.0.0/0, ::/0, 128.0.0.0/1"
 		fi

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -115,6 +115,15 @@ function installQuestions() {
 			CLIENT_DNS_2="${CLIENT_DNS_1}"
 		fi
 	done
+	
+	#Allowed IPs
+	until [[ ${ALLOWED_IPS} =~ ^.*$ ]]; do
+		read -rp "Allowed IPs list:
+ " -e -i "0.0.0.0/0, ::/0, 128.0.0.0/1" ALLOWED_IPS
+ 		if [[ ${ALLOWED_IPS} == "" ]]; then
+			ALLOWED_IPS="0.0.0.0/0, ::/0, 128.0.0.0/1"
+		fi
+	done
 
 	echo ""
 	echo "Okay, that was all I needed. We are ready to setup your WireGuard server now."
@@ -179,7 +188,8 @@ SERVER_PORT=${SERVER_PORT}
 SERVER_PRIV_KEY=${SERVER_PRIV_KEY}
 SERVER_PUB_KEY=${SERVER_PUB_KEY}
 CLIENT_DNS_1=${CLIENT_DNS_1}
-CLIENT_DNS_2=${CLIENT_DNS_2}" >/etc/wireguard/params
+CLIENT_DNS_2=${CLIENT_DNS_2}
+ALLOWED_IPS=${ALLOWED_IPS}" >/etc/wireguard/params
 
 	# Add server interface
 	echo "[Interface]
@@ -310,7 +320,7 @@ DNS = ${CLIENT_DNS_1},${CLIENT_DNS_2}
 PublicKey = ${SERVER_PUB_KEY}
 PresharedKey = ${CLIENT_PRE_SHARED_KEY}
 Endpoint = ${ENDPOINT}
-AllowedIPs = 0.0.0.0/0,::/0" >>"${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
+AllowedIPs = ${ALLOWED_IPS}" >>"${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 
 	# Add the client as a peer to the server
 	echo -e "\n### Client ${CLIENT_NAME}


### PR DESCRIPTION
This adds allowed_ips param to params file. So clients profiles will be generated with changable AllowedIPs param instead of hardcoded param as before.