### PR TITLE
Generate random default IPv6 address

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -131,8 +131,9 @@ function installQuestions() {
 		read -rp "Server WireGuard IPv4: " -e -i 10.66.66.1 SERVER_WG_IPV4
 	done
 
+	DEFAULT_IPV6=$(echo "`date +%s%N``cat /etc/machine-id`" | sha256sum | cut -c 55-65 | sed 's/../&\n/g' | xargs printf "fd%s:%s%s:%s%s::1")
 	until [[ ${SERVER_WG_IPV6} =~ ^([a-f0-9]{1,4}:){3,4}: ]]; do
-		read -rp "Server WireGuard IPv6: " -e -i fd42:42:42::1 SERVER_WG_IPV6
+		read -rp "Server WireGuard IPv6: " -e -i "${DEFAULT_IPV6}" SERVER_WG_IPV6
 	done
 
 	# Generate random number within private ports range


### PR DESCRIPTION
Hi,

this is a very nice script! I've added generating random default IPv6 address as discussed in #283. Tested on Linux Mint 21.1, Ubuntu 22.04 and Debian 11.

Let me know what you think.
