### PR TITLE
Removing `resolvconf` Installation from debian and ubuntu installation

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -173,14 +173,14 @@ function installWireGuard() {
 	# Install WireGuard tools and module
 	if [[ ${OS} == 'ubuntu' ]] || [[ ${OS} == 'debian' && ${VERSION_ID} -gt 10 ]]; then
 		apt-get update
-		apt-get install -y wireguard iptables resolvconf qrencode
+		apt-get install -y wireguard iptables qrencode
 	elif [[ ${OS} == 'debian' ]]; then
 		if ! grep -rqs "^deb .* buster-backports" /etc/apt/; then
 			echo "deb http://deb.debian.org/debian buster-backports main" >/etc/apt/sources.list.d/backports.list
 			apt-get update
 		fi
 		apt update
-		apt-get install -y iptables resolvconf qrencode
+		apt-get install -y iptables qrencode
 		apt-get install -y -t buster-backports wireguard
 	elif [[ ${OS} == 'fedora' ]]; then
 		if [[ ${VERSION_ID} -lt 32 ]]; then


### PR DESCRIPTION
Referencing issue: #479

Most cloud providers injects their own DNS settings into /etc/resolv.conf file and/or running a separate DNS provider such as systemd-resolved. Running `apt-get install resolveconf` will break /etc/resolv.conf.  

Tested with GCP debian-cloud/debian-12 image, both DNS forwarding for clients and server lookup still works.

<!---
❗️ Please read ❗️
➡️ Please make sure you've followed the guidelines: https://github.com/angristan/wireguard-install#contributing
✅ Please make sure your changes are tested and working
🗣️ Please avoid large PRs, and discuss changes in a GitHub issue first
✋ If the changes are too big and not in line with the project, they will probably be rejected. Remember that this script is meant to be simple and easy to use.
--->
