### PR TITLE
add firewalld FORWARD rule

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -237,7 +237,11 @@ PrivateKey = ${SERVER_PRIV_KEY}" >"/etc/wireguard/${SERVER_WG_NIC}.conf"
 		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-3)".0"
 		FIREWALLD_IPV6_ADDRESS=$(echo "${SERVER_WG_IPV6}" | sed 's/:[^:]*$/:0/')
 		echo "PostUp = firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'
-PostDown = firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
+PostUp = firewall-cmd --direct --add-rule ipv4 filter FORWARD 1 -i ${SERVER_WG_NIC} -j ACCEPT && firewall-cmd --direct --add-rule ipv4 filter FORWARD 1 -o ${SERVER_WG_NIC} -j ACCEPT
+PostUp = firewall-cmd --direct --add-rule ipv6 filter FORWARD 1 -i ${SERVER_WG_NIC} -j ACCEPT && firewall-cmd --direct --add-rule ipv6 filter FORWARD 1 -o ${SERVER_WG_NIC} -j ACCEPT
+PostDown = firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'
+PostDown = firewall-cmd --direct --remove-rule ipv4 filter FORWARD 1 -i ${SERVER_WG_NIC} -j ACCEPT && firewall-cmd --direct --remove-rule ipv4 filter FORWARD 1 -o ${SERVER_WG_NIC} -j ACCEPT 
+PostDown = firewall-cmd --direct --remove-rule ipv6 filter FORWARD 1 -i ${SERVER_WG_NIC} -j ACCEPT && firewall-cmd --direct --remove-rule ipv6 filter FORWARD 1 -o ${SERVER_WG_NIC} -j ACCEPT" >>"/etc/wireguard/${SERVER_WG_NIC}.conf "
 	else
 		echo "PostUp = iptables -I INPUT -p udp --dport ${SERVER_PORT} -j ACCEPT
 PostUp = iptables -I FORWARD -i ${SERVER_PUB_NIC} -o ${SERVER_WG_NIC} -j ACCEPT


### PR DESCRIPTION
add firewalld FORWARD rule in PostUp & PostDown stage.

Rule Example: 
PostUp: 
* firewall-cmd --direct --add-rule ipv4 filter FORWARD 1  -i  ${SERVER_WG_NIC} -j ACCEPT 
* firewall-cmd --direct --add-rule ipv4 filter FORWARD 1 -o  ${SERVER_WG_NIC} -j ACCEPT

PostDown:
* firewall-cmd --direct --remove-rule ipv4 filter FORWARD 1  -i  ${SERVER_WG_NIC} -j ACCEPT 
* firewall-cmd --direct --remove-rule ipv4 filter FORWARD 1 -o  ${SERVER_WG_NIC} -j ACCEPT

<!---
❗️ Please read ❗️
➡️ Please make sure you've followed the guidelines: https://github.com/angristan/wireguard-install#contributing
✅ Please make sure your changes are tested and working
🗣️ Please avoid large PRs, and discuss changes in a GitHub issue first
✋ If the changes are too big and not in line with the project, they will probably be rejected. Remember that this script is meant to be simple and easy to use.
--->
