### PR TITLE
fix: /etc/wireguard file permissions on fedora

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -286,6 +286,11 @@ PostDown = ip6tables -t nat -D POSTROUTING -o ${SERVER_PUB_NIC} -j MASQUERADE" >
 	echo "net.ipv4.ip_forward = 1
 net.ipv6.conf.all.forwarding = 1" >/etc/sysctl.d/wg.conf
 
+	if [[ ${OS} == 'fedora' ]]; then
+		chmod -v 700 /etc/wireguard
+		chmod -v 600 /etc/wireguard/*
+	fi
+
 	if [[ ${OS} == 'alpine' ]]; then
 		sysctl -p /etc/sysctl.d/wg.conf
 		rc-update add sysctl


### PR DESCRIPTION
Fedora install may end up with incorrect permissions on `/etc/wireguard` after recursive `chmod 600`, causing `wg-quick` to fail. This adds a final permission fix on Fedora to enforce `700` on the directory and `600` on config files once they are created.