### PR TITLE
Expand WireGuard subnet from /24 to /16 for more clients

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -147,7 +147,7 @@ function installQuestions() {
 	done
 
 	until [[ ${SERVER_WG_IPV4} =~ ^([0-9]{1,3}\.){3} ]]; do
-		read -rp "Server WireGuard IPv4: " -e -i 10.66.66.1 SERVER_WG_IPV4
+		read -rp "Server WireGuard IPv4: " -e -i 172.242.0.1 SERVER_WG_IPV4
 	done
 
 	until [[ ${SERVER_WG_IPV6} =~ ^([a-f0-9]{1,4}:){3,4}: ]]; do
@@ -258,15 +258,15 @@ ALLOWED_IPS=${ALLOWED_IPS}" >/etc/wireguard/params
 
 	# Add server interface
 	echo "[Interface]
-Address = ${SERVER_WG_IPV4}/24,${SERVER_WG_IPV6}/64
+Address = ${SERVER_WG_IPV4}/16,${SERVER_WG_IPV6}/64
 ListenPort = ${SERVER_PORT}
 PrivateKey = ${SERVER_PRIV_KEY}" >"/etc/wireguard/${SERVER_WG_NIC}.conf"
 
 	if pgrep firewalld; then
-		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-3)".0"
+		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-2)".0.0"
 		FIREWALLD_IPV6_ADDRESS=$(echo "${SERVER_WG_IPV6}" | sed 's/:[^:]*$/:0/')
-		echo "PostUp = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'
-PostDown = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
+		echo "PostUp = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/16 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/16 masquerade'
+PostDown = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/16 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/16 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
 	else
 		echo "PostUp = iptables -I INPUT -p udp --dport ${SERVER_PORT} -j ACCEPT
 PostUp = iptables -I FORWARD -i ${SERVER_PUB_NIC} -o ${SERVER_WG_NIC} -j ACCEPT
@@ -360,23 +360,32 @@ function newClient() {
 		fi
 	done
 
-	for DOT_IP in {2..254}; do
-		DOT_EXISTS=$(grep -c "${SERVER_WG_IPV4::-1}${DOT_IP}" "/etc/wireguard/${SERVER_WG_NIC}.conf")
-		if [[ ${DOT_EXISTS} == '0' ]]; then
-			break
-		fi
+	CLIENT_IP_FOUND=0
+	for OCTET3 in {0..255}; do
+		for OCTET4 in {1..254}; do
+			CANDIDATE_IP="$(echo "$SERVER_WG_IPV4" | awk -F '.' '{print $1"."$2}').${OCTET3}.${OCTET4}"
+			if [[ "${CANDIDATE_IP}" == "${SERVER_WG_IPV4}" ]]; then
+				continue
+			fi
+			if ! grep -q "${CANDIDATE_IP}/32" "/etc/wireguard/${SERVER_WG_NIC}.conf"; then
+				CLIENT_IP_FOUND=1
+				break 2
+			fi
+		done
 	done
 
-	if [[ ${DOT_EXISTS} == '1' ]]; then
+	if [[ ${CLIENT_IP_FOUND} == '0' ]]; then
 		echo ""
-		echo "The subnet configured supports only 253 clients."
+		echo "The subnet configured supports only 65534 clients."
 		exit 1
 	fi
 
-	BASE_IP=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2"."$3 }')
+	DOT_IP=$((OCTET3 * 256 + OCTET4))
+	BASE_IP=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2 }')
+	SUGGESTED_IP="${OCTET3}.${OCTET4}"
 	until [[ ${IPV4_EXISTS} == '0' ]]; do
-		read -rp "Client WireGuard IPv4: ${BASE_IP}." -e -i "${DOT_IP}" DOT_IP
-		CLIENT_WG_IPV4="${BASE_IP}.${DOT_IP}"
+		read -rp "Client WireGuard IPv4: ${BASE_IP}." -e -i "${SUGGESTED_IP}" LAST_TWO
+		CLIENT_WG_IPV4="${BASE_IP}.${LAST_TWO}"
 		IPV4_EXISTS=$(grep -c "$CLIENT_WG_IPV4/32" "/etc/wireguard/${SERVER_WG_NIC}.conf")
 
 		if [[ ${IPV4_EXISTS} != 0 ]]; then


### PR DESCRIPTION
## Description

This PR expands the default WireGuard subnet configuration from a /24 network to a /16 network, significantly increasing the number of supported clients.

### Changes Made

- **Default server IPv4**: Changed from `10.66.66.1` to `172.242.0.1`
- **Subnet mask**: Changed from `/24` to `/16` for the server interface
- **Client IP allocation**: Refactored the client IP assignment logic to support the larger address space:
  - Previous: Iterated through the last octet (2-254) supporting ~253 clients
  - New: Iterates through the 3rd and 4th octets (0-255 and 1-254) supporting ~65,534 clients
- **Firewall rules**: Updated firewalld masquerade rules to use `/16` CIDR notation and adjusted the address extraction logic to work with the new subnet structure

### Technical Details

The client IP discovery algorithm now:
1. Searches through all available IPs in the /16 subnet (excluding the server IP)
2. Checks for conflicts with existing client configurations
3. Suggests the first available IP to the user
4. Allows manual override if needed

This maintains backward compatibility with the user interaction flow while dramatically expanding capacity.

### Testing

Manual testing recommended to verify:
- Server installation with new default IP range
- Client addition and IP assignment
- Firewall rule generation on systems with firewalld enabled

https://claude.ai/code/session_01EehRFvcURqB66TEjsXCrr1