### PR TITLE
Expand WireGuard subnet from /24 to /16 for more clients

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -147,7 +147,7 @@ function installQuestions() {
 	done
 
 	until [[ ${SERVER_WG_IPV4} =~ ^([0-9]{1,3}\.){3} ]]; do
-		read -rp "Server WireGuard IPv4: " -e -i 10.66.66.1 SERVER_WG_IPV4
+		read -rp "Server WireGuard IPv4: " -e -i 10.242.0.1 SERVER_WG_IPV4
 	done
 
 	until [[ ${SERVER_WG_IPV6} =~ ^([a-f0-9]{1,4}:){3,4}: ]]; do
@@ -258,15 +258,15 @@ ALLOWED_IPS=${ALLOWED_IPS}" >/etc/wireguard/params
 
 	# Add server interface
 	echo "[Interface]
-Address = ${SERVER_WG_IPV4}/24,${SERVER_WG_IPV6}/64
+Address = ${SERVER_WG_IPV4}/16,${SERVER_WG_IPV6}/64
 ListenPort = ${SERVER_PORT}
 PrivateKey = ${SERVER_PRIV_KEY}" >"/etc/wireguard/${SERVER_WG_NIC}.conf"
 
 	if pgrep firewalld; then
-		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-3)".0"
+		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-2)".0.0"
 		FIREWALLD_IPV6_ADDRESS=$(echo "${SERVER_WG_IPV6}" | sed 's/:[^:]*$/:0/')
-		echo "PostUp = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'
-PostDown = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
+		echo "PostUp = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/16 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/16 masquerade'
+PostDown = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/16 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/16 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
 	else
 		echo "PostUp = iptables -I INPUT -p udp --dport ${SERVER_PORT} -j ACCEPT
 PostUp = iptables -I FORWARD -i ${SERVER_PUB_NIC} -o ${SERVER_WG_NIC} -j ACCEPT
@@ -360,20 +360,31 @@ function newClient() {
 		fi
 	done
 
-	for DOT_IP in {2..254}; do
-		DOT_EXISTS=$(grep -c "${SERVER_WG_IPV4::-1}${DOT_IP}" "/etc/wireguard/${SERVER_WG_NIC}.conf")
-		if [[ ${DOT_EXISTS} == '0' ]]; then
-			break
-		fi
+	BASE_IP_16=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2 }')
+	FOUND_IP=0
+	DOT_IP=""
+	for OCTET3 in {0..255}; do
+		for OCTET4 in {2..254}; do
+			CANDIDATE="${BASE_IP_16}.${OCTET3}.${OCTET4}"
+			if [[ "${CANDIDATE}" == "${SERVER_WG_IPV4}" ]]; then
+				continue
+			fi
+			DOT_EXISTS=$(grep -c "${CANDIDATE}" "/etc/wireguard/${SERVER_WG_NIC}.conf")
+			if [[ ${DOT_EXISTS} == '0' ]]; then
+				DOT_IP="${OCTET3}.${OCTET4}"
+				FOUND_IP=1
+				break 2
+			fi
+		done
 	done
 
-	if [[ ${DOT_EXISTS} == '1' ]]; then
+	if [[ ${FOUND_IP} == '0' ]]; then
 		echo ""
-		echo "The subnet configured supports only 253 clients."
+		echo "The subnet configured supports only 65534 clients."
 		exit 1
 	fi
 
-	BASE_IP=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2"."$3 }')
+	BASE_IP=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2 }')
 	until [[ ${IPV4_EXISTS} == '0' ]]; do
 		read -rp "Client WireGuard IPv4: ${BASE_IP}." -e -i "${DOT_IP}" DOT_IP
 		CLIENT_WG_IPV4="${BASE_IP}.${DOT_IP}"
@@ -386,10 +397,11 @@ function newClient() {
 		fi
 	done
 
+	IPV6_DOT_IP=$(printf '%x' $(( $(echo "${CLIENT_WG_IPV4}" | cut -d'.' -f3) * 256 + $(echo "${CLIENT_WG_IPV4}" | cut -d'.' -f4) )))
 	BASE_IP=$(echo "$SERVER_WG_IPV6" | awk -F '::' '{ print $1 }')
 	until [[ ${IPV6_EXISTS} == '0' ]]; do
-		read -rp "Client WireGuard IPv6: ${BASE_IP}::" -e -i "${DOT_IP}" DOT_IP
-		CLIENT_WG_IPV6="${BASE_IP}::${DOT_IP}"
+		read -rp "Client WireGuard IPv6: ${BASE_IP}::" -e -i "${IPV6_DOT_IP}" IPV6_DOT_IP
+		CLIENT_WG_IPV6="${BASE_IP}::${IPV6_DOT_IP}"
 		IPV6_EXISTS=$(grep -c "${CLIENT_WG_IPV6}/128" "/etc/wireguard/${SERVER_WG_NIC}.conf")
 
 		if [[ ${IPV6_EXISTS} != 0 ]]; then


### PR DESCRIPTION
## Description

This PR expands the default WireGuard subnet configuration from a /24 network to a /16 network, significantly increasing the number of supported clients from 253 to 65,534.

### Changes Made

- **Default IPv4 address**: Changed from `10.66.66.1/24` to `10.242.0.1/16`
- **Client IP allocation**: Updated the client IP assignment logic to support the larger /16 subnet by iterating through both the third and fourth octets (0-255 and 2-254 respectively)
- **Firewall rules**: Updated firewall-cmd rules to use `/16` CIDR notation and adjusted the address extraction logic to use the first two octets instead of three
- **IPv6 mapping**: Added automatic IPv6 address derivation from the assigned IPv4 address to ensure consistent client addressing across both protocols

### Technical Details

The subnet expansion required changes to:
1. IP address validation and assignment loops to handle the larger address space
2. Firewall configuration for both PostUp and PostDown rules
3. IPv6 address generation to map from the expanded IPv4 space
4. User prompts and error messages to reflect the new capacity

### Testing

Manual testing recommended to verify:
- Server installation with new default subnet
- Client addition and IP assignment within the /16 range
- Firewall rules are correctly applied on systems using firewalld
- IPv6 address generation matches expected values

https://claude.ai/code/session_01FejU3PJh3qaFGsAKkGSGVu