### PR TITLE
Expand WireGuard subnet from /24 to /16 for more clients

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -147,7 +147,7 @@ function installQuestions() {
 	done
 
 	until [[ ${SERVER_WG_IPV4} =~ ^([0-9]{1,3}\.){3} ]]; do
-		read -rp "Server WireGuard IPv4: " -e -i 10.66.66.1 SERVER_WG_IPV4
+		read -rp "Server WireGuard IPv4: " -e -i 10.242.0.1 SERVER_WG_IPV4
 	done
 
 	until [[ ${SERVER_WG_IPV6} =~ ^([a-f0-9]{1,4}:){3,4}: ]]; do
@@ -258,15 +258,15 @@ ALLOWED_IPS=${ALLOWED_IPS}" >/etc/wireguard/params
 
 	# Add server interface
 	echo "[Interface]
-Address = ${SERVER_WG_IPV4}/24,${SERVER_WG_IPV6}/64
+Address = ${SERVER_WG_IPV4}/16,${SERVER_WG_IPV6}/64
 ListenPort = ${SERVER_PORT}
 PrivateKey = ${SERVER_PRIV_KEY}" >"/etc/wireguard/${SERVER_WG_NIC}.conf"
 
 	if pgrep firewalld; then
 		FIREWALLD_IPV4_ADDRESS=$(echo "${SERVER_WG_IPV4}" | cut -d"." -f1-3)".0"
 		FIREWALLD_IPV6_ADDRESS=$(echo "${SERVER_WG_IPV6}" | sed 's/:[^:]*$/:0/')
-		echo "PostUp = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'
-PostDown = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/24 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/24 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
+		echo "PostUp = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --add-port ${SERVER_PORT}/udp && firewall-cmd --add-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/16 masquerade' && firewall-cmd --add-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/64 masquerade'
+PostDown = firewall-cmd --zone=public --add-interface=${SERVER_WG_NIC} && firewall-cmd --remove-port ${SERVER_PORT}/udp && firewall-cmd --remove-rich-rule='rule family=ipv4 source address=${FIREWALLD_IPV4_ADDRESS}/16 masquerade' && firewall-cmd --remove-rich-rule='rule family=ipv6 source address=${FIREWALLD_IPV6_ADDRESS}/64 masquerade'" >>"/etc/wireguard/${SERVER_WG_NIC}.conf"
 	else
 		echo "PostUp = iptables -I INPUT -p udp --dport ${SERVER_PORT} -j ACCEPT
 PostUp = iptables -I FORWARD -i ${SERVER_PUB_NIC} -o ${SERVER_WG_NIC} -j ACCEPT
@@ -360,23 +360,34 @@ function newClient() {
 		fi
 	done
 
-	for DOT_IP in {2..254}; do
-		DOT_EXISTS=$(grep -c "${SERVER_WG_IPV4::-1}${DOT_IP}" "/etc/wireguard/${SERVER_WG_NIC}.conf")
-		if [[ ${DOT_EXISTS} == '0' ]]; then
-			break
+	BASE_NET=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2 }')
+	THIRD_OCTET=0
+	FOURTH_OCTET=2
+	DOT_EXISTS=1
+	for THIRD_OCTET in {0..255}; do
+		START_FOURTH=0
+		if [[ ${THIRD_OCTET} -eq 0 ]]; then
+			START_FOURTH=2
 		fi
+		for FOURTH_OCTET in $(seq "${START_FOURTH}" 254); do
+			DOT_EXISTS=$(grep -c "${BASE_NET}.${THIRD_OCTET}.${FOURTH_OCTET}" "/etc/wireguard/${SERVER_WG_NIC}.conf")
+			if [[ ${DOT_EXISTS} == '0' ]]; then
+				break 2
+			fi
+		done
 	done
 
 	if [[ ${DOT_EXISTS} == '1' ]]; then
 		echo ""
-		echo "The subnet configured supports only 253 clients."
+		echo "The subnet configured supports only 65,533 clients."
 		exit 1
 	fi
 
-	BASE_IP=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2"."$3 }')
+	BASE_IP=$(echo "$SERVER_WG_IPV4" | awk -F '.' '{ print $1"."$2 }')
 	until [[ ${IPV4_EXISTS} == '0' ]]; do
-		read -rp "Client WireGuard IPv4: ${BASE_IP}." -e -i "${DOT_IP}" DOT_IP
-		CLIENT_WG_IPV4="${BASE_IP}.${DOT_IP}"
+		read -rp "Client WireGuard IPv4 third octet: ${BASE_IP}." -e -i "${THIRD_OCTET}" THIRD_OCTET
+		read -rp "Client WireGuard IPv4 fourth octet: ${BASE_IP}.${THIRD_OCTET}." -e -i "${FOURTH_OCTET}" FOURTH_OCTET
+		CLIENT_WG_IPV4="${BASE_IP}.${THIRD_OCTET}.${FOURTH_OCTET}"
 		IPV4_EXISTS=$(grep -c "$CLIENT_WG_IPV4/32" "/etc/wireguard/${SERVER_WG_NIC}.conf")
 
 		if [[ ${IPV4_EXISTS} != 0 ]]; then
@@ -388,8 +399,8 @@ function newClient() {
 
 	BASE_IP=$(echo "$SERVER_WG_IPV6" | awk -F '::' '{ print $1 }')
 	until [[ ${IPV6_EXISTS} == '0' ]]; do
-		read -rp "Client WireGuard IPv6: ${BASE_IP}::" -e -i "${DOT_IP}" DOT_IP
-		CLIENT_WG_IPV6="${BASE_IP}::${DOT_IP}"
+		read -rp "Client WireGuard IPv6: ${BASE_IP}::" -e -i "${THIRD_OCTET}:${FOURTH_OCTET}" IPV6_SUFFIX
+		CLIENT_WG_IPV6="${BASE_IP}::${IPV6_SUFFIX}"
 		IPV6_EXISTS=$(grep -c "${CLIENT_WG_IPV6}/128" "/etc/wireguard/${SERVER_WG_NIC}.conf")
 
 		if [[ ${IPV6_EXISTS} != 0 ]]; then


### PR DESCRIPTION
## Description

This PR expands the WireGuard server subnet configuration from a /24 network to a /16 network, significantly increasing the number of supported clients from 253 to 65,533.

### Changes Made

1. **Default IPv4 Address**: Changed default server WireGuard IPv4 from `10.66.66.1` to `10.242.0.1`

2. **Subnet Mask Updates**:
   - Server interface address: `/24` → `/16`
   - Firewalld IPv4 masquerade rules: `/24` → `/16`
   - Firewalld IPv6 masquerade rules: `/24` → `/64`

3. **Client IP Assignment Logic**: Refactored to support the larger /16 subnet:
   - Changed from single-octet iteration (2-254) to dual-octet iteration (third and fourth octets)
   - Updated IP availability checking to scan the full /16 range
   - Modified user prompts to request both third and fourth octets separately
   - Updated IPv6 suffix handling to use the new variable names

4. **User Feedback**: Updated error message to reflect new capacity (253 → 65,533 clients)

### Testing

Manual testing recommended to verify:
- Server installation with new default IP
- Client addition with new IP assignment prompts
- Firewall rules configuration on systems using firewalld

https://claude.ai/code/session_01TcTbVx4yNhRscKMh27xTcH