### PR TITLE
Write QR code to PNG (feat request #267)

### DIFF
--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -436,6 +436,7 @@ AllowedIPs = ${CLIENT_WG_IPV4}/32,${CLIENT_WG_IPV6}/128" >>"/etc/wireguard/${SER
 	if command -v qrencode &>/dev/null; then
 		echo -e "${GREEN}\nHere is your client config file as a QR Code:\n${NC}"
 		qrencode -t ansiutf8 -l L <"${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
+		qrencode -t png -o "${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.png" -r "${HOME_DIR}/${SERVER_WG_NIC}-client-${CLIENT_NAME}.conf"
 		echo ""
 	fi
 


### PR DESCRIPTION
Resolves https://github.com/angristan/wireguard-install/discussions/267

Writes the client config QR code to a PNG with same file name as the conf file. This is useful when generating multiple client configs to distribute.