### PR TITLE
Add native Flatcar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Supported distributions:
 - CentOS Stream >= 8
 - Debian >= 10
 - Fedora >= 32
+- Flatcar Linux
 - Oracle Linux
 - Rocky Linux >= 8
 - Ubuntu >= 18.04
@@ -36,7 +37,8 @@ chmod +x wireguard-install.sh
 ./wireguard-install.sh
 ```
 
-It will install WireGuard (kernel module and tools) on the server, configure it, create a systemd service and a client configuration file.
+It will set up WireGuard on the server, configure it and create a client configuration file.
+On distributions that require it, the script also installs the needed WireGuard packages and enables the appropriate service.
 
 Run the script again to add or remove clients!
 

--- a/wireguard-install.sh
+++ b/wireguard-install.sh
@@ -80,8 +80,10 @@ function checkOS() {
 				echo -e "${RED}Failed to install virt-what. Continuing without virtualization check.${NC}"
 			fi
 		fi
+	elif [[ ${OS} == "flatcar" ]] || [[ ${OS} == "coreos" && -n "${FLATCAR_BOARD:-}" ]]; then
+		OS=flatcar
 	else
-		echo "Looks like you aren't running this installer on a Debian, Ubuntu, Fedora, CentOS, AlmaLinux, Oracle or Arch Linux system"
+		echo "Looks like you aren't running this installer on a Debian, Ubuntu, Fedora, CentOS, AlmaLinux, Rocky, Oracle, Arch, Alpine or Flatcar Linux system"
 		exit 1
 	fi
 }
@@ -223,6 +225,9 @@ function installWireGuard() {
 		installPackages dnf install -y wireguard-tools qrencode iptables
 	elif [[ ${OS} == 'arch' ]]; then
 		installPackages pacman -S --needed --noconfirm wireguard-tools qrencode
+	elif [[ ${OS} == 'flatcar' ]]; then
+		# Flatcar provides the required WireGuard tooling natively
+		:
 	elif [[ ${OS} == 'alpine' ]]; then
 		apk update
 		installPackages apk add wireguard-tools iptables libqrencode-tools
@@ -522,6 +527,9 @@ function uninstallWg() {
 			yum remove --noautoremove wireguard-tools qrencode
 		elif [[ ${OS} == 'arch' ]]; then
 			pacman -Rs --noconfirm wireguard-tools qrencode
+		elif [[ ${OS} == 'flatcar' ]]; then
+			# Flatcar provides the required WireGuard tooling natively
+			:
 		elif [[ ${OS} == 'alpine' ]]; then
 			(cd qrencode-4.1.1 || exit && make uninstall)
 			rm -rf qrencode-* || exit


### PR DESCRIPTION
Detect Flatcar explicitly, skip package management on Flatcar hosts, and update the README so the supported platform list and setup behavior stay accurate.